### PR TITLE
feat: Add optional version increment flag to commons build scripts

### DIFF
--- a/scripts/run_build_common.sh
+++ b/scripts/run_build_common.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+# Default values
+INCREMENT_VERSION=false
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --increment-version|-i) INCREMENT_VERSION=true ;;
+        --help|-h) 
+            echo "Usage: $0 [OPTIONS]"
+            echo "Options:"
+            echo "  --increment-version, -i  Increment the patch version before building"
+            echo "  --help, -h              Show this help message"
+            exit 0
+            ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Navigate to the commons directory
@@ -12,14 +31,18 @@ ABOUT_FILE="src/kugel_common/__about__.py"
 CURRENT_VERSION=$(grep "__version__" $ABOUT_FILE | cut -d '"' -f 2)
 echo "現在のバージョン: $CURRENT_VERSION"
 
-# バージョンをインクリメント（ここでは単純な例としています）
-IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))
-NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-echo "新しいバージョン: $NEW_VERSION"
-
-# __about__.py を新しいバージョンで更新
-sed -i "s/__version__ = \"$CURRENT_VERSION\"/__version__ = \"$NEW_VERSION\"/" $ABOUT_FILE
+if [ "$INCREMENT_VERSION" = true ]; then
+    # バージョンをインクリメント（ここでは単純な例としています）
+    IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+    VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))
+    NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+    echo "新しいバージョン: $NEW_VERSION"
+    
+    # __about__.py を新しいバージョンで更新
+    sed -i "s/__version__ = \"$CURRENT_VERSION\"/__version__ = \"$NEW_VERSION\"/" $ABOUT_FILE
+else
+    echo "バージョンは変更しません"
+fi
 
 # プロジェクトをビルド
 # ここにビルドコマンドを挿入（例: python setup.py bdist_wheel）


### PR DESCRIPTION
## Summary
- Cherry-picked commit from private repository to add optional version increment flag functionality to commons build scripts
- This enhancement allows more flexible version management when building the commons library

## Changes
- Added optional `--increment-version` (or `-i`) flag to commons build scripts
- Changed default behavior to NOT increment version automatically
- Version increment now requires explicit flag usage
- Useful for development and testing scenarios where version changes aren't needed

## Source
Cherry-picked from private repository commit: `500f4d7`

🤖 Generated with [Claude Code](https://claude.ai/code)