### PR TITLE
feat: Add Redis port mapping for external access

### DIFF
--- a/services/docker-compose.override.yaml
+++ b/services/docker-compose.override.yaml
@@ -94,3 +94,4 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -257,6 +257,8 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    ports:
+      - "6380:6379"
     networks:
       - kugelpos_net
 


### PR DESCRIPTION
## Summary
- Expose Redis on port 6380 to allow connections from external machines
- Added port mapping configuration to `docker-compose.yaml` for consistency with MongoDB settings

## Test plan
- [x] Verify Redis container starts with port 6380 exposed
- [x] Confirm external connections work via `redis-cli -h <host> -p 6380 ping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)