### PR TITLE
refactor: Clean up CategoryPromoPlugin redundant code (#64)

### DIFF
--- a/services/cart/app/services/strategies/sales_promo/category_promo.py
+++ b/services/cart/app/services/strategies/sales_promo/category_promo.py
@@ -149,7 +149,9 @@ class CategoryPromoPlugin(AbstractSalesPromo):
             logger.warning(f"Failed to parse detail for promotion {promo.promotion_code}: {e}")
             return None
 
-    def _build_category_promotion_map(self, promotions: list) -> dict[str, PromotionInfo]:
+    def _build_category_promotion_map(
+        self, promotions: list[PromotionMasterDocument]
+    ) -> dict[str, PromotionInfo]:
         """
         Build a mapping of category codes to their best promotion.
 
@@ -159,9 +161,9 @@ class CategoryPromoPlugin(AbstractSalesPromo):
             promotions: List of PromotionMasterDocument objects
 
         Returns:
-            dict: Mapping of category_code to (promotion_code, promotion_type, discount_rate)
+            dict[str, PromotionInfo]: Mapping of category_code to PromotionInfo
         """
-        category_map = {}
+        category_map: dict[str, PromotionInfo] = {}
 
         for promo in promotions:
             if promo.promotion_type != "category_discount":


### PR DESCRIPTION
## Summary

Refactoring of `CategoryPromoPlugin` based on code review findings.

- Remove unnecessary `discount_amount` calculation (`calc_line_item_logic` recalculates it using configured rounding method)
- Remove unused `target_store_codes` field from `CategoryPromoDetail` (already filtered by master-data API)
- Add `PromotionInfo` TypedDict to make promotion map structure explicit
- Simplify `_has_category_promotion` using `any()`

## Note

This is a **refactoring-only** change. No behavior changes — all existing tests pass.

## Test plan

- [x] All service tests passed (127 tests across 7 services)
- [x] `test_category_promo.py` passed
- [x] `test_category_promo_plugin.py` (unit tests) passed

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)