### PR TITLE
fix: Replace SystemError with TerminalCloseException in close_terminal_async

### DIFF
--- a/services/terminal/app/services/terminal_service.py
+++ b/services/terminal/app/services/terminal_service.py
@@ -677,7 +677,7 @@ class TerminalService:
             await self._publish_open_close_log(close_message)
         except Exception as e:
             message = f"Cannot publish open_close_log. terminal_id: {self.terminal_id}, terminal: {terminal}"
-            raise SystemError(message=message, logger=logger, original_exception=e)
+            raise TerminalCloseException(message=message, logger=logger, original_exception=e)
         return open_close_log
 
     # Terminal information retrieval methods


### PR DESCRIPTION
## Summary

- Fix a bug where Python's built-in `SystemError` was used with keyword arguments in `terminal_service.py:680`, causing a `TypeError` at runtime
- Replace `SystemError` with `TerminalCloseException` (a custom exception already imported and used in the same method)

## Details

When `_publish_open_close_log()` fails during `close_terminal_async()`, the code attempted to raise `SystemError(message=..., logger=..., original_exception=...)`. Since Python's built-in `SystemError` does not accept keyword arguments, a `TypeError` was raised instead of the intended exception.

At this point the DB transaction is already committed, so the client received an unexpected 500 error, causing operators to mistakenly believe the terminal close had failed.

## Test plan

- [x] All service unit tests passed (7/7 PASSED)
- [x] All service Docker builds succeeded
- [x] Health checks passed on all ports

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)