### PR TITLE
fix: Add missing mock for get_terminal_info_async in open/close tests

### DIFF
--- a/services/terminal/tests/test_api_terminals.py
+++ b/services/terminal/tests/test_api_terminals.py
@@ -391,6 +391,7 @@ class TestTerminalOpen:
         app = make_app()
         mock_service = AsyncMock()
         mock_service.open_terminal_async.return_value = _make_open_close_log(operation="open")
+        mock_service.get_terminal_info_async.return_value = _make_terminal_doc(status="Opened")
 
         with patch("app.api.v1.terminal.get_terminal_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -409,6 +410,7 @@ class TestTerminalOpen:
         app = make_app()
         mock_service = AsyncMock()
         mock_service.open_terminal_async.return_value = _make_open_close_log(operation="open")
+        mock_service.get_terminal_info_async.return_value = _make_terminal_doc(status="Opened")
 
         with patch("app.api.v1.terminal.get_terminal_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -441,6 +443,7 @@ class TestTerminalClose:
         app = make_app()
         mock_service = AsyncMock()
         mock_service.close_terminal_async.return_value = _make_open_close_log(operation="close")
+        mock_service.get_terminal_info_async.return_value = _make_terminal_doc(status="Closed")
 
         with patch("app.api.v1.terminal.get_terminal_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -456,6 +459,7 @@ class TestTerminalClose:
         app = make_app()
         mock_service = AsyncMock()
         mock_service.close_terminal_async.return_value = _make_open_close_log(operation="close")
+        mock_service.get_terminal_info_async.return_value = _make_terminal_doc(status="Closed")
 
         with patch("app.api.v1.terminal.get_terminal_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- Add `get_terminal_info_async` mock return value to `TestTerminalOpen` and `TestTerminalClose` test cases
- PR #68 introduced `create_terminal_token()` calls in open/close endpoints that call `get_terminal_info_async()`, but tests did not mock this method
- Without the mock, `AsyncMock` objects were passed to `jwt.encode()`, causing `TypeError: Object of type AsyncMock is not JSON serializable`

Closes #73

## Test plan
- [x] `pytest services/terminal/tests/test_api_terminals.py -v` — all 29 tests pass
- [x] `./scripts/run_all_tests.sh` — all 134 tests pass across 7 services

🤖 Generated with [Claude Code](https://claude.ai/code)