### PR TITLE
Decouple PromotionMasterDocument.detail from CategoryPromoDetail

### DIFF
--- a/services/master-data/app/api/common/schemas_transformer.py
+++ b/services/master-data/app/api/common/schemas_transformer.py
@@ -212,9 +212,9 @@ class SchemasTransformer:
         detail = None
         if promotion_doc.detail:
             detail = BaseCategoryPromoDetail(
-                target_store_codes=promotion_doc.detail.target_store_codes or [],
-                target_category_codes=promotion_doc.detail.target_category_codes,
-                discount_rate=promotion_doc.detail.discount_rate,
+                target_store_codes=promotion_doc.detail.get("target_store_codes", []),
+                target_category_codes=promotion_doc.detail.get("target_category_codes", []),
+                discount_rate=promotion_doc.detail.get("discount_rate", 0.0),
             )
 
         return BasePromotionResponse(

--- a/services/master-data/app/api/v1/promotion_master.py
+++ b/services/master-data/app/api/v1/promotion_master.py
@@ -18,7 +18,6 @@ from app.api.v1.schemas import (
 from app.api.v1.schemas_transformer import SchemasTransformerV1
 from app.dependencies.get_master_services import get_promotion_master_service_async
 from app.dependencies.common import parse_sort
-from app.models.documents.promotion_master_document import PromotionMasterDocument
 
 router = APIRouter()
 logger = getLogger(__name__)
@@ -61,11 +60,11 @@ async def create_promotion(
         # Build detail if provided
         detail = None
         if promotion.detail:
-            detail = PromotionMasterDocument.CategoryPromoDetail(
-                target_store_codes=promotion.detail.target_store_codes or [],
-                target_category_codes=promotion.detail.target_category_codes,
-                discount_rate=promotion.detail.discount_rate,
-            )
+            detail = {
+                "target_store_codes": promotion.detail.target_store_codes or [],
+                "target_category_codes": promotion.detail.target_category_codes,
+                "discount_rate": promotion.detail.discount_rate,
+            }
 
         new_promotion = await service.create_promotion_async(
             promotion_code=promotion.promotion_code,
@@ -300,12 +299,11 @@ async def update_promotion(
         if promotion.is_active is not None:
             update_data["is_active"] = promotion.is_active
         if promotion.detail is not None:
-            detail = PromotionMasterDocument.CategoryPromoDetail(
-                target_store_codes=promotion.detail.target_store_codes or [],
-                target_category_codes=promotion.detail.target_category_codes,
-                discount_rate=promotion.detail.discount_rate,
-            )
-            update_data["detail"] = detail.model_dump()
+            update_data["detail"] = {
+                "target_store_codes": promotion.detail.target_store_codes or [],
+                "target_category_codes": promotion.detail.target_category_codes,
+                "discount_rate": promotion.detail.discount_rate,
+            }
 
         updated_promotion = await service.update_promotion_async(
             promotion_code=promotion_code, update_data=update_data

--- a/services/master-data/app/models/documents/promotion_master_document.py
+++ b/services/master-data/app/models/documents/promotion_master_document.py
@@ -1,9 +1,8 @@
 # Copyright 2025 masa@kugel  # # Licensed under the Apache License, Version 2.0 (the "License");  # you may not use this file except in compliance with the License.  # You may obtain a copy of the License at  # #     http://www.apache.org/licenses/LICENSE-2.0  # # Unless required by applicable law or agreed to in writing, software  # distributed under the License is distributed on an "AS IS" BASIS,  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  # See the License for the specific language governing permissions and  # limitations under the License.
 from typing import Optional
 from datetime import datetime
-from pydantic import Field, field_validator
+from pydantic import field_validator
 
-from kugel_common.models.documents.base_document_model import BaseDocumentModel
 from app.models.documents.abstract_document import AbstractDocument
 
 
@@ -14,36 +13,9 @@ class PromotionMasterDocument(AbstractDocument):
     This class defines the structure for promotion information which is used to apply
     discounts to items based on various criteria. The promotion system is designed to be
     extensible, supporting different promotion types through the promotion_type field.
+    The detail field stores type-specific configuration as a plain dict, with validation
+    handled by the service layer based on promotion_type.
     """
-
-    class CategoryPromoDetail(BaseDocumentModel):
-        """
-        Nested class representing category-specific promotion details.
-
-        Contains configuration for category-based promotions including target stores,
-        target categories, and the discount rate to be applied.
-        """
-        target_store_codes: Optional[list[str]] = Field(
-            default_factory=list,
-            description="Target store codes. Empty list means all stores."
-        )
-        target_category_codes: list[str] = Field(
-            default_factory=list,
-            description="Target category codes for this promotion."
-        )
-        discount_rate: float = Field(
-            default=0.0,
-            gt=0,
-            le=100,
-            description="Discount rate in percentage (e.g., 10.0 = 10% off)"
-        )
-
-        @field_validator("target_category_codes")
-        @classmethod
-        def validate_target_categories(cls, v: list[str]) -> list[str]:
-            if not v:
-                raise ValueError("target_category_codes must contain at least one category code")
-            return v
 
     tenant_id: Optional[str] = None
     promotion_code: Optional[str] = None
@@ -54,7 +26,7 @@ class PromotionMasterDocument(AbstractDocument):
     end_datetime: Optional[datetime] = None
     is_active: bool = True
     is_deleted: bool = False
-    detail: Optional[CategoryPromoDetail] = None
+    detail: Optional[dict] = None
 
     @field_validator("end_datetime")
     @classmethod

--- a/services/master-data/app/services/promotion_master_service.py
+++ b/services/master-data/app/services/promotion_master_service.py
@@ -42,9 +42,7 @@ class PromotionMasterService:
         end_datetime: datetime,
         description: Optional[str] = None,
         is_active: bool = True,
-        detail: Optional[
-            PromotionMasterDocument.CategoryPromoDetail
-        ] = None,
+        detail: Optional[dict] = None,
     ) -> PromotionMasterDocument:
         """
         Create a new promotion in the database.
@@ -76,16 +74,12 @@ class PromotionMasterService:
             if detail is None:
                 message = "detail is required for category_discount type"
                 raise InvalidRequestDataException(message, logger)
-            if (
-                not detail.target_category_codes
-                or len(detail.target_category_codes) == 0
-            ):
+            target_cats = detail.get("target_category_codes", [])
+            if not target_cats or len(target_cats) == 0:
                 message = "target_category_codes must contain at least one category code"
                 raise InvalidRequestDataException(message, logger)
-            if (
-                detail.discount_rate <= 0
-                or detail.discount_rate > 100
-            ):
+            rate = detail.get("discount_rate", 0)
+            if rate <= 0 or rate > 100:
                 message = "discount_rate must be between 0 and 100"
                 raise InvalidRequestDataException(message, logger)
 
@@ -224,7 +218,7 @@ class PromotionMasterService:
                 if (
                     promo.detail
                     and category_code
-                    in promo.detail.target_category_codes
+                    in promo.detail.get("target_category_codes", [])
                 ):
                     if promotion_type is None or promo.promotion_type == promotion_type:
                         result.append(promo)

--- a/services/master-data/tests/test_promotion_master_service.py
+++ b/services/master-data/tests/test_promotion_master_service.py
@@ -19,11 +19,11 @@ def make_category_detail(
     target_store_codes=None,
     discount_rate=10.0,
 ):
-    return PromotionMasterDocument.CategoryPromoDetail(
-        target_category_codes=target_category_codes or ["001"],
-        target_store_codes=target_store_codes or [],
-        discount_rate=discount_rate,
-    )
+    return {
+        "target_category_codes": target_category_codes or ["001"],
+        "target_store_codes": target_store_codes or [],
+        "discount_rate": discount_rate,
+    }
 
 
 def make_promotion_doc(
@@ -134,10 +134,7 @@ class TestPromotionMasterServiceCreate:
         so this test verifies the service-level check via a manually constructed detail."""
         mock_repo.get_promotion_by_code_async.return_value = None
 
-        # Bypass Pydantic model validation by patching the detail object
-        detail = MagicMock(spec=PromotionMasterDocument.CategoryPromoDetail)
-        detail.target_category_codes = []
-        detail.discount_rate = 10.0
+        detail = {"target_category_codes": [], "discount_rate": 10.0}
 
         with pytest.raises(InvalidRequestDataException):
             await service.create_promotion_async(
@@ -156,9 +153,7 @@ class TestPromotionMasterServiceCreate:
         construction and test the service-level validation directly."""
         mock_repo.get_promotion_by_code_async.return_value = None
 
-        detail = MagicMock(spec=PromotionMasterDocument.CategoryPromoDetail)
-        detail.target_category_codes = ["001"]
-        detail.discount_rate = 150.0
+        detail = {"target_category_codes": ["001"], "discount_rate": 150.0}
 
         with pytest.raises(InvalidRequestDataException):
             await service.create_promotion_async(
@@ -422,3 +417,60 @@ class TestPromotionMasterServiceDelete:
 
         with pytest.raises(DocumentNotFoundException):
             await service.delete_promotion_async("NONEXISTENT")
+
+
+class TestTransformPromotion:
+    """Tests for SchemasTransformer.transform_promotion with dict-based detail."""
+
+    def _make_doc(self, detail=None):
+        return PromotionMasterDocument(
+            promotion_code="PROMO-01",
+            promotion_type="category_discount",
+            name="Test Promo",
+            start_datetime=START,
+            end_datetime=END,
+            is_active=True,
+            detail=detail,
+            created_at=START,
+            updated_at=END,
+        )
+
+    def test_transform_with_detail(self):
+        """Dict detail is correctly transformed to BaseCategoryPromoDetail."""
+        from app.api.common.schemas_transformer import SchemasTransformer
+
+        doc = self._make_doc(detail={
+            "target_store_codes": ["S001", "S002"],
+            "target_category_codes": ["001", "002"],
+            "discount_rate": 15.0,
+        })
+        result = SchemasTransformer().transform_promotion(doc)
+
+        assert result.promotion_code == "PROMO-01"
+        assert result.detail is not None
+        assert result.detail.target_store_codes == ["S001", "S002"]
+        assert result.detail.target_category_codes == ["001", "002"]
+        assert result.detail.discount_rate == 15.0
+
+    def test_transform_with_none_detail(self):
+        """None detail produces None in response."""
+        from app.api.common.schemas_transformer import SchemasTransformer
+
+        doc = self._make_doc(detail=None)
+        result = SchemasTransformer().transform_promotion(doc)
+
+        assert result.detail is None
+
+    def test_transform_with_empty_store_codes(self):
+        """Detail with no target_store_codes defaults to empty list."""
+        from app.api.common.schemas_transformer import SchemasTransformer
+
+        doc = self._make_doc(detail={
+            "target_category_codes": ["001"],
+            "discount_rate": 10.0,
+        })
+        result = SchemasTransformer().transform_promotion(doc)
+
+        assert result.detail.target_store_codes == []
+        assert result.detail.target_category_codes == ["001"]
+        assert result.detail.discount_rate == 10.0


### PR DESCRIPTION
## Summary

- Change `PromotionMasterDocument.detail` from `Optional[CategoryPromoDetail]` to `Optional[dict]` in master-data service, decoupling the document model from a specific promotion type
- Move type-specific validation to the service layer (dict access pattern)
- Update API route to construct plain dicts instead of `CategoryPromoDetail` objects
- Update schemas transformer to use `dict.get()` for safe access
- API request/response schemas remain unchanged (no breaking API change)

Closes #72

## Test plan

- [x] `test_promotion_master_service.py` — 24 existing tests updated and passing (dict-based detail)
- [x] `TestTransformPromotion` — 3 new tests for `transform_promotion` with dict detail, None detail, and missing keys
- [x] `test_promotion_master.py` — Integration tests passing (full API flow)
- [x] All 133 test files across all 7 services passed with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)