### PR TITLE
feat: Default performance test auth to JWT, add --api-key option

### DIFF
--- a/services/cart/performance_tests/scripts/run_multiple_tests.sh
+++ b/services/cart/performance_tests/scripts/run_multiple_tests.sh
@@ -63,6 +63,18 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PERF_TEST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Parse --api-key flag from arguments
+AUTH_MODE="jwt"
+AUTH_FLAG=""
+AUTH_SUFFIX=""
+for arg in "$@"; do
+    if [ "$arg" = "--api-key" ]; then
+        AUTH_MODE="apikey"
+        AUTH_FLAG="--api-key"
+        AUTH_SUFFIX="_apikey"
+    fi
+done
+
 # Output directory for test results
 OUTPUT_DIR="${PERF_TEST_DIR}/results"
 BACKUP_BASE_DIR="${PERF_TEST_DIR}/results_backup"
@@ -76,18 +88,6 @@ BACKUP_DIR="${BACKUP_BASE_DIR}/${TIMESTAMP}${AUTH_SUFFIX}"
 #TEST_DURATION="10m"
 TEST_PATTERNS=(50 100)
 TEST_DURATION="10m"
-
-# Parse --api-key flag from arguments
-AUTH_MODE="jwt"
-AUTH_FLAG=""
-AUTH_SUFFIX=""
-for arg in "$@"; do
-    if [ "$arg" = "--api-key" ]; then
-        AUTH_MODE="apikey"
-        AUTH_FLAG="--api-key"
-        AUTH_SUFFIX="_apikey"
-    fi
-done
 
 # Error tracking
 declare -a FAILED_TESTS=()

--- a/services/cart/performance_tests/scripts/run_multiple_tests.sh
+++ b/services/cart/performance_tests/scripts/run_multiple_tests.sh
@@ -34,8 +34,12 @@
 #   - Prevents lock contention on transaction_no generation
 #   - More realistic performance testing
 #
+# Authentication mode:
+#   - Default: JWT (locustfile_jwt.py)
+#   - --api-key: Legacy API Key (locustfile.py)
+#
 # Usage:
-#   ./run_multiple_tests.sh
+#   ./run_multiple_tests.sh [--api-key]
 #
 # Requirements:
 #   - .env.test file in project root with TENANT_ID, API_KEY, etc.
@@ -65,13 +69,25 @@ BACKUP_BASE_DIR="${PERF_TEST_DIR}/results_backup"
 
 # Timestamp for this test run
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_DIR="${BACKUP_BASE_DIR}/${TIMESTAMP}"
+BACKUP_DIR="${BACKUP_BASE_DIR}/${TIMESTAMP}${AUTH_SUFFIX}"
 
 # Test patterns: users and duration
 #TEST_PATTERNS=(20 30 40 50)
 #TEST_DURATION="10m"
 TEST_PATTERNS=(50 100)
 TEST_DURATION="10m"
+
+# Parse --api-key flag from arguments
+AUTH_MODE="jwt"
+AUTH_FLAG=""
+AUTH_SUFFIX=""
+for arg in "$@"; do
+    if [ "$arg" = "--api-key" ]; then
+        AUTH_MODE="apikey"
+        AUTH_FLAG="--api-key"
+        AUTH_SUFFIX="_apikey"
+    fi
+done
 
 # Error tracking
 declare -a FAILED_TESTS=()
@@ -121,13 +137,13 @@ backup_results() {
 
     # Move result files to backup directory
     local files_found=false
-    if ls "${OUTPUT_DIR}"/Custom_${pattern}users_*.html >/dev/null 2>&1; then
-        mv "${OUTPUT_DIR}"/Custom_${pattern}users_*.html "${backup_subdir}/" 2>/dev/null || true
+    if ls "${OUTPUT_DIR}"/Custom_${pattern}users${AUTH_SUFFIX}_*.html >/dev/null 2>&1; then
+        mv "${OUTPUT_DIR}"/Custom_${pattern}users${AUTH_SUFFIX}_*.html "${backup_subdir}/" 2>/dev/null || true
         files_found=true
     fi
 
-    if ls "${OUTPUT_DIR}"/Custom_${pattern}users_*.csv >/dev/null 2>&1; then
-        mv "${OUTPUT_DIR}"/Custom_${pattern}users_*.csv "${backup_subdir}/" 2>/dev/null || true
+    if ls "${OUTPUT_DIR}"/Custom_${pattern}users${AUTH_SUFFIX}_*.csv >/dev/null 2>&1; then
+        mv "${OUTPUT_DIR}"/Custom_${pattern}users${AUTH_SUFFIX}_*.csv "${backup_subdir}/" 2>/dev/null || true
         files_found=true
     fi
 
@@ -180,7 +196,7 @@ run_test_pattern() {
 
     # Step 2: Cleanup previous test data
     print_info "Step 2/6: Cleaning up previous test data..."
-    if bash "${SCRIPT_DIR}/run_perf_test.sh" cleanup; then
+    if bash "${SCRIPT_DIR}/run_perf_test.sh" cleanup ${AUTH_FLAG}; then
         print_success "Test data cleanup completed"
     else
         print_error "Test data cleanup failed (continuing anyway)"
@@ -192,7 +208,7 @@ run_test_pattern() {
     print_info "Step 3/6: Setting up new test data (multi-terminal mode)..."
     # Use users + 10 terminals to ensure enough capacity
     local num_terminals=$((users + 10))
-    if bash "${SCRIPT_DIR}/run_perf_test.sh" setup "${num_terminals}"; then
+    if bash "${SCRIPT_DIR}/run_perf_test.sh" setup "${num_terminals}" ${AUTH_FLAG}; then
         print_success "Test data setup completed (${num_terminals} terminals created)"
     else
         print_error "Test data setup failed (continuing anyway)"
@@ -203,7 +219,7 @@ run_test_pattern() {
 
     # Step 4: Run performance test
     print_info "Step 4/6: Running performance test (${users} users, ${TEST_DURATION})..."
-    if bash "${SCRIPT_DIR}/run_perf_test.sh" custom "${users}" "${TEST_DURATION}"; then
+    if bash "${SCRIPT_DIR}/run_perf_test.sh" custom "${users}" "${TEST_DURATION}" ${AUTH_FLAG}; then
         print_success "Performance test completed"
     else
         print_error "Performance test failed or incomplete"
@@ -247,6 +263,7 @@ main() {
     print_info "Test Configuration:"
     echo "  - Test Patterns: ${TEST_PATTERNS[*]} users"
     echo "  - Test Duration: ${TEST_DURATION}"
+    echo "  - Auth Mode: ${AUTH_MODE} ($([ "${AUTH_MODE}" = "jwt" ] && echo "locustfile_jwt.py" || echo "locustfile.py"))"
     echo "  - Mode: Multi-Terminal (each user gets unique terminal_id)"
     echo "  - Terminals per pattern: N+10 (e.g., 30 terminals for 20 users)"
     echo "  - Backup Directory: ${BACKUP_DIR}"

--- a/services/cart/performance_tests/scripts/run_perf_test.sh
+++ b/services/cart/performance_tests/scripts/run_perf_test.sh
@@ -20,8 +20,12 @@
 # - Pattern 1: 20 concurrent users for 5 minutes
 # - Pattern 2: 40 concurrent users for 5 minutes
 #
+# Authentication mode:
+#   - Default: JWT (locustfile_jwt.py)
+#   - --api-key: Legacy API Key (locustfile.py)
+#
 # Usage:
-#   ./run_perf_test.sh [pattern1|pattern2|all]
+#   ./run_perf_test.sh [pattern1|pattern2|all] [--api-key]
 #
 # Requirements:
 #   - .env.test file in project root with TENANT_ID, API_KEY, etc.
@@ -43,6 +47,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PERF_TEST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CART_DIR="$(cd "${PERF_TEST_DIR}/.." && pwd)"
 ROOT_DIR="$(cd "${CART_DIR}/../.." && pwd)"
+
+# Parse --api-key flag from arguments
+AUTH_MODE="jwt"
+LOCUSTFILE="locustfile_jwt.py"
+AUTH_SUFFIX=""
+ARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "--api-key" ]; then
+        AUTH_MODE="apikey"
+        LOCUSTFILE="locustfile.py"
+        AUTH_SUFFIX="_apikey"
+    else
+        ARGS+=("$arg")
+    fi
+done
+set -- "${ARGS[@]}"
 
 # Output directory for test results
 OUTPUT_DIR="${PERF_TEST_DIR}/results"
@@ -153,6 +173,7 @@ load_env() {
     print_message "${GREEN}" "  ✓ API_KEY: ${API_KEY:0:10}..."
     print_message "${GREEN}" "  ✓ TENANT_ID: ${TENANT_ID}"
     print_message "${GREEN}" "  ✓ BASE_URL_CART: ${BASE_URL_CART}"
+    print_message "${GREEN}" "  ✓ Auth Mode: ${AUTH_MODE} (${LOCUSTFILE})"
 }
 
 ###############################################################################
@@ -176,11 +197,14 @@ run_test_pattern() {
     export PERF_TEST_SPAWN_RATE="${spawn_rate}"
     export PERF_TEST_RUN_TIME="${run_time}"
 
+    # Add auth mode suffix to pattern name for file distinction
+    local file_prefix="${pattern_name}${AUTH_SUFFIX}"
+
     # Output files
-    local html_report="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}.html"
-    local csv_stats="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}_stats.csv"
-    local csv_history="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}_history.csv"
-    local csv_failures="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}_failures.csv"
+    local html_report="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}.html"
+    local csv_stats="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}_stats.csv"
+    local csv_history="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}_history.csv"
+    local csv_failures="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}_failures.csv"
 
     # Check if terminals_config.json exists (multi-terminal mode)
     if [ -f "${PERF_TEST_DIR}/terminals_config.json" ]; then
@@ -195,14 +219,14 @@ run_test_pattern() {
     cd "${PERF_TEST_DIR}"
 
     pipenv run locust \
-        -f "locustfile.py" \
+        -f "${LOCUSTFILE}" \
         --host="${BASE_URL_CART}" \
         --users="${num_users}" \
         --spawn-rate="${spawn_rate}" \
         --run-time="${run_time}" \
         --headless \
         --html="${html_report}" \
-        --csv="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}" \
+        --csv="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}" \
         --loglevel=INFO
 
     local exit_code=$?
@@ -213,7 +237,7 @@ run_test_pattern() {
         print_message "${GREEN}" "  CSV Stats: ${csv_stats}"
 
         # Generate Add Item specific chart
-        local add_item_chart="${OUTPUT_DIR}/${pattern_name}_${TIMESTAMP}_add_item.html"
+        local add_item_chart="${OUTPUT_DIR}/${file_prefix}_${TIMESTAMP}_add_item.html"
         print_message "${BLUE}" "\n  Generating Add Item chart..."
         cd "${PERF_TEST_DIR}"
         pipenv run python generate_item_chart.py "${csv_stats}" "${add_item_chart}"
@@ -305,7 +329,7 @@ run_all() {
 ###############################################################################
 show_usage() {
     cat << EOF
-Usage: $0 [OPTION]
+Usage: $0 [OPTION] [--api-key]
 
 Run performance tests for Cart Service (Multi-Terminal Mode)
 
@@ -318,13 +342,17 @@ OPTIONS:
     cleanup             Cleanup test data only
     help                Show this help message
 
+AUTH MODE:
+    (default)           Use JWT authentication (locustfile_jwt.py)
+    --api-key           Use legacy API Key authentication (locustfile.py)
+
 EXAMPLES:
-    $0                      # Run all patterns (with auto setup/cleanup)
-    $0 all                  # Run all patterns (with auto setup/cleanup)
-    $0 pattern1             # Run only 20 users pattern (requires existing data)
-    $0 pattern2             # Run only 40 users pattern (requires existing data)
-    $0 custom 50 10m        # Run 50 concurrent users for 10 minutes
-    $0 custom 100 30s       # Run 100 concurrent users for 30 seconds
+    $0                      # Run all patterns with JWT (default)
+    $0 all                  # Run all patterns with JWT (default)
+    $0 pattern1             # Run only 20 users pattern with JWT
+    $0 pattern1 --api-key   # Run only 20 users pattern with API Key
+    $0 custom 50 10m        # Run 50 concurrent users for 10 minutes (JWT)
+    $0 custom 100 30s --api-key  # Run 100 users for 30 seconds (API Key)
     $0 setup                # Setup test data with 50 terminals (default)
     $0 setup 100            # Setup test data with 100 terminals
     $0 cleanup              # Cleanup test data only


### PR DESCRIPTION
## Summary
- Change default authentication in `run_perf_test.sh` and `run_multiple_tests.sh` from API Key (`locustfile.py`) to JWT (`locustfile_jwt.py`)
- Add `--api-key` flag to select legacy API Key authentication when needed
- Result filenames include `_apikey` suffix when using API Key mode for easy distinction

## Performance Test Results (20 users, 3 min)

| Endpoint | JWT Avg (ms) | API Key Avg (ms) | Improvement |
|----------|-------------|-------------------|-------------|
| Create Cart | 47 | 101 | 53% faster |
| Cancel Cart | 73 | 181 | 60% faster |
| Add Item | 49 | 62 | 21% faster |
| **Aggregated** | **49** | **68** | **28% faster** |

Both modes: 0 failures across all endpoints.

## Test plan
- [x] `./run_perf_test.sh help` shows updated usage with `--api-key` option
- [x] Default run (no flag) uses `locustfile_jwt.py` — verified via `Auth Mode: jwt` output
- [x] `--api-key` flag selects `locustfile.py` — verified via `Auth Mode: apikey` output
- [x] Result filenames correctly distinguished (`Custom_20users_*` vs `Custom_20users_apikey_*`)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)