### PR TITLE
fix: Add Docker log rotation and fix prod healthcheck

### DIFF
--- a/services/docker-compose.prod.yaml
+++ b/services/docker-compose.prod.yaml
@@ -1,9 +1,16 @@
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 services:
   # Infrastructure services
   mongodb:
     image: mongo:7.0
     container_name: mongodb
     restart: always
+    logging: *default-logging
     environment:
       MONGO_INITDB_DATABASE: admin
     ports:
@@ -25,6 +32,7 @@ services:
     image: redis:latest
     container_name: redis
     restart: always
+    logging: *default-logging
     ports:
       - "6379:6379"
     volumes:
@@ -42,11 +50,7 @@ services:
     image: kugelpos-account:prod
     container_name: kugelpos-account-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8000:8000"
     environment:
@@ -74,11 +78,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-account-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:account"
     depends_on:
       - account
@@ -99,11 +99,7 @@ services:
     image: kugelpos-terminal:prod
     container_name: kugelpos-terminal-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8001:8000"
     environment:
@@ -137,11 +133,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-terminal-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:terminal"
     depends_on:
       - terminal
@@ -162,11 +154,7 @@ services:
     image: kugelpos-master-data:prod
     container_name: kugelpos-master-data-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8002:8000"
       - "50051:50051"
@@ -198,11 +186,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-master-data-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:master-data"
     depends_on:
       - master-data
@@ -223,11 +207,7 @@ services:
     image: kugelpos-cart:prod
     container_name: kugelpos-cart-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8003:8000"
     environment:
@@ -262,11 +242,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-cart-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:cart"
     depends_on:
       - cart
@@ -287,11 +263,7 @@ services:
     image: kugelpos-report:prod
     container_name: kugelpos-report-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8004:8000"
     environment:
@@ -322,11 +294,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-report-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:report"
     depends_on:
       - report
@@ -347,11 +315,7 @@ services:
     image: kugelpos-journal:prod
     container_name: kugelpos-journal-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8005:8000"
     environment:
@@ -381,11 +345,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-journal-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:journal"
     depends_on:
       - journal
@@ -406,11 +366,7 @@ services:
     image: kugelpos-stock:prod
     container_name: kugelpos-stock-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     ports:
       - "8006:8000"
     environment:
@@ -441,11 +397,7 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-stock-dapr-prod
     restart: always
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     network_mode: "service:stock"
     depends_on:
       - stock

--- a/services/docker-compose.prod.yaml
+++ b/services/docker-compose.prod.yaml
@@ -42,6 +42,11 @@ services:
     image: kugelpos-account:prod
     container_name: kugelpos-account-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8000:8000"
     environment:
@@ -57,7 +62,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -69,6 +74,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-account-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:account"
     depends_on:
       - account
@@ -89,6 +99,11 @@ services:
     image: kugelpos-terminal:prod
     container_name: kugelpos-terminal-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8001:8000"
     environment:
@@ -110,7 +125,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -122,6 +137,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-terminal-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:terminal"
     depends_on:
       - terminal
@@ -142,6 +162,11 @@ services:
     image: kugelpos-master-data:prod
     container_name: kugelpos-master-data-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8002:8000"
       - "50051:50051"
@@ -161,7 +186,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -173,6 +198,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-master-data-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:master-data"
     depends_on:
       - master-data
@@ -193,6 +223,11 @@ services:
     image: kugelpos-cart:prod
     container_name: kugelpos-cart-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8003:8000"
     environment:
@@ -215,7 +250,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -227,6 +262,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-cart-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:cart"
     depends_on:
       - cart
@@ -247,6 +287,11 @@ services:
     image: kugelpos-report:prod
     container_name: kugelpos-report-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8004:8000"
     environment:
@@ -265,7 +310,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -277,6 +322,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-report-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:report"
     depends_on:
       - report
@@ -297,6 +347,11 @@ services:
     image: kugelpos-journal:prod
     container_name: kugelpos-journal-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8005:8000"
     environment:
@@ -314,7 +369,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -326,6 +381,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-journal-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:journal"
     depends_on:
       - journal
@@ -346,6 +406,11 @@ services:
     image: kugelpos-stock:prod
     container_name: kugelpos-stock-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     ports:
       - "8006:8000"
     environment:
@@ -364,7 +429,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -376,6 +441,11 @@ services:
     image: daprio/daprd:latest
     container_name: kugelpos-stock-dapr-prod
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     network_mode: "service:stock"
     depends_on:
       - stock

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -1,3 +1,8 @@
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "3"
 
 services:
   account:
@@ -5,11 +10,7 @@ services:
       context: ./account
       dockerfile: Dockerfile
     image: masakugel/kugelpos.account:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./account/.env
         required: false
@@ -19,7 +20,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -30,11 +31,7 @@ services:
       context: ./terminal
       dockerfile: Dockerfile
     image: masakugel/kugelpos.terminal:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./terminal/.env
         required: false
@@ -53,7 +50,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -64,11 +61,7 @@ services:
       context: ./master-data
       dockerfile: Dockerfile
     image: masakugel/kugelpos.master-data:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./master-data/.env
         required: false
@@ -82,7 +75,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -93,11 +86,7 @@ services:
       context: ./cart
       dockerfile: Dockerfile
     image: masakugel/kugelpos.cart:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./cart/.env
         required: false
@@ -112,7 +101,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -123,11 +112,7 @@ services:
       context: ./report
       dockerfile: Dockerfile
     image: masakugel/kugelpos.report:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./report/.env
         required: false
@@ -143,7 +128,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -154,11 +139,7 @@ services:
       context: ./journal
       dockerfile: Dockerfile
     image: masakugel/kugelpos.journal:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./journal/.env
         required: false
@@ -173,7 +154,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -184,11 +165,7 @@ services:
       context: ./stock
       dockerfile: Dockerfile
     image: masakugel/kugelpos.stock:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     env_file:
       - path: ./stock/.env
         required: false
@@ -204,7 +181,7 @@ services:
       - kugelpos_net
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -212,11 +189,7 @@ services:
 
   dapr_account:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "account", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - account
@@ -228,11 +201,7 @@ services:
 
   dapr_terminal:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "terminal", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - terminal
@@ -244,11 +213,7 @@ services:
 
   dapr_master_data:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "master-data", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - master-data
@@ -260,11 +225,7 @@ services:
 
   dapr_cart:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "cart", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - cart
@@ -278,11 +239,7 @@ services:
 
   dapr_report:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "report", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - report
@@ -294,11 +251,7 @@ services:
 
   dapr_journal:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "journal", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - journal
@@ -310,11 +263,7 @@ services:
 
   dapr_stock:
     image: daprio/daprd:latest
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+    logging: *default-logging
     command: ["./daprd", "-app-id", "stock", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - stock
@@ -327,6 +276,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    logging: *default-logging
     ports:
       - "6380:6379"
     networks:
@@ -336,6 +286,7 @@ services:
     image: mongo:7.0
     container_name: mongodb
     hostname: mongodb
+    logging: *default-logging
     ports:
       - "27017:27017"
     command: mongod --replSet rs0 --bind_ip_all
@@ -351,7 +302,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-  
+
 networks:
   kugelpos_net:
     driver: bridge

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -5,6 +5,11 @@ services:
       context: ./account
       dockerfile: Dockerfile
     image: masakugel/kugelpos.account:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./account/.env
         required: false
@@ -25,6 +30,11 @@ services:
       context: ./terminal
       dockerfile: Dockerfile
     image: masakugel/kugelpos.terminal:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./terminal/.env
         required: false
@@ -54,6 +64,11 @@ services:
       context: ./master-data
       dockerfile: Dockerfile
     image: masakugel/kugelpos.master-data:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./master-data/.env
         required: false
@@ -78,6 +93,11 @@ services:
       context: ./cart
       dockerfile: Dockerfile
     image: masakugel/kugelpos.cart:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./cart/.env
         required: false
@@ -103,6 +123,11 @@ services:
       context: ./report
       dockerfile: Dockerfile
     image: masakugel/kugelpos.report:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./report/.env
         required: false
@@ -129,6 +154,11 @@ services:
       context: ./journal
       dockerfile: Dockerfile
     image: masakugel/kugelpos.journal:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./journal/.env
         required: false
@@ -154,6 +184,11 @@ services:
       context: ./stock
       dockerfile: Dockerfile
     image: masakugel/kugelpos.stock:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     env_file:
       - path: ./stock/.env
         required: false
@@ -177,6 +212,11 @@ services:
 
   dapr_account:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "account", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - account
@@ -188,6 +228,11 @@ services:
 
   dapr_terminal:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "terminal", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - terminal
@@ -199,6 +244,11 @@ services:
 
   dapr_master_data:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "master-data", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - master-data
@@ -210,6 +260,11 @@ services:
 
   dapr_cart:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "cart", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - cart
@@ -223,6 +278,11 @@ services:
 
   dapr_report:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "report", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - report
@@ -234,6 +294,11 @@ services:
 
   dapr_journal:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "journal", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - journal
@@ -245,6 +310,11 @@ services:
 
   dapr_stock:
     image: daprio/daprd:latest
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
     command: ["./daprd", "-app-id", "stock", "-app-port", "8000", "-dapr-http-port", "3500", "-config", "/dapr/config.yaml", "-components-path", "./dapr/components"]
     depends_on:
       - stock


### PR DESCRIPTION
## Summary
- Add `json-file` logging driver with `max-size: 50m`, `max-file: 3` to all 14 services (7 app + 7 Dapr sidecars) in both `docker-compose.yaml` and `docker-compose.prod.yaml`
- Replace `curl -f` healthcheck with `python urllib.request` in `docker-compose.prod.yaml` since prod images don't include curl

Closes #91

## Test plan
- [x] `docker compose -f docker-compose.yaml config` validates successfully
- [x] `docker compose -f docker-compose.prod.yaml config` validates successfully
- [x] All 7 services report `healthy` in `docker ps` after recreate
- [x] Log rotation config confirmed via `docker inspect --format '{{json .HostConfig.LogConfig}}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)