### PR TITLE
perf: Delete cart cache on bill/cancel instead of saving completed state (#94)

### DIFF
--- a/services/cart/app/services/cart_service.py
+++ b/services/cart/app/services/cart_service.py
@@ -302,8 +302,11 @@ class CartService(ICartService):
         tranlog = await self.tran_service.create_tranlog_async(cart_doc)
         logger.debug(f"CancelTransaction-> tranlog: {tranlog}")
 
-        # Save to cache
-        await self.__cache_cart_async(cart_doc=cart_doc, cart_status=CartStatus.Cancelled)
+        # Remove cart from cache (transaction data is already saved in MongoDB)
+        await self.__remove_cached_cart_async(self.cart_id)
+
+        # Update cart status in memory for response
+        cart_doc.status = CartStatus.Cancelled.value
 
         return cart_doc
 
@@ -720,8 +723,11 @@ class CartService(ICartService):
         tranlog = await self.tran_service.create_tranlog_async(cart_doc)
         logger.debug(f"Bill-> tranlog: {tranlog}")
 
-        # Save to cache
-        await self.__cache_cart_async(cart_doc=cart_doc, cart_status=CartStatus.Completed)
+        # Remove cart from cache (transaction data is already saved in MongoDB)
+        await self.__remove_cached_cart_async(self.cart_id)
+
+        # Update cart status in memory for response
+        cart_doc.status = CartStatus.Completed.value
 
         return cart_doc
 


### PR DESCRIPTION
## Summary
- Delete cart from Redis cache after bill/cancel instead of saving with Completed/Cancelled status
- Completed/cancelled carts are never read back from cache, so saving them wastes Redis memory

## Changes
- `cancel_transaction_async`: `__cache_cart_async(Cancelled)` → `__remove_cached_cart_async()`
- `bill_async`: `__cache_cart_async(Completed)` → `__remove_cached_cart_async()`

## Expected Benefits
- Reduced Redis memory accumulation from completed cart documents (~16KB each)
- Improved tail latency (P99/Max) under sustained load
- Benefits are proportional to traffic volume; more significant in longer-running scenarios

## Test plan
- [x] Unit tests pass (405 passed)
- [ ] Performance test with Redis memory monitoring (5+ min recommended)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)