### PR TITLE
fix(cart): prevent double-cleanup on tranlog transaction commit (#96)

### DIFF
--- a/services/cart/app/services/tran_service.py
+++ b/services/cart/app/services/tran_service.py
@@ -272,26 +272,27 @@ class TranService:
         ]
 
         # Save tranlog to database
-        async with await self.tranlog_repository.start_transaction() as session:
-            try:
-                self.tranlog_delivery_status_repo.set_session(session)
-                await self.tranlog_delivery_status_repo.create_status_async(
-                    event_id=event_id,
-                    transaction_no=tranlog.transaction_no,
-                    payload=event_message,
-                    services=event_distinations,
-                )
-                tranlog = await self.tranlog_repository.create_tranlog_async(tranlog)
-                await self.tranlog_repository.commit_transaction()
+        # Manual session mgmt (no `async with`): context manager re-aborts after commit ended session — issue #96.
+        session = await self.tranlog_repository.start_transaction()
+        try:
+            self.tranlog_delivery_status_repo.set_session(session)
+            await self.tranlog_delivery_status_repo.create_status_async(
+                event_id=event_id,
+                transaction_no=tranlog.transaction_no,
+                payload=event_message,
+                services=event_distinations,
+            )
+            tranlog = await self.tranlog_repository.create_tranlog_async(tranlog)
+            await self.tranlog_repository.commit_transaction()
 
-            except Exception as e:
-                await self.tranlog_repository.abort_transaction()
-                message = f"Error creating tranlog: {e}"
-                raise InternalErrorException(message, logger) from e
-            finally:
-                # clear session
-                self.tranlog_repository.set_session(session=None)
-                self.tranlog_delivery_status_repo.set_session(session=None)
+        except Exception as e:
+            await self.tranlog_repository.abort_transaction()
+            message = f"Error creating tranlog: {e}"
+            raise InternalErrorException(message, logger) from e
+        finally:
+            # clear session
+            self.tranlog_repository.set_session(session=None)
+            self.tranlog_delivery_status_repo.set_session(session=None)
 
         # Publish tranlog
         await self._publish_tranlog_async(event_message)
@@ -517,25 +518,26 @@ class TranService:
         ]
 
         # Save tranlog to database
-        async with await self.tranlog_repository.start_transaction() as session:
-            try:
-                self.tranlog_delivery_status_repo.set_session(session)
-                await self.tranlog_delivery_status_repo.create_status_async(
-                    event_id=event_id,
-                    transaction_no=tran.transaction_no,
-                    payload=event_message,
-                    services=event_distinations,
-                )
-                tran = await self.tranlog_repository.create_tranlog_async(tran)
-                await self.tranlog_repository.commit_transaction()
-            except Exception as e:
-                await self.tranlog_repository.abort_transaction()
-                message = f"Error creating tranlog: {e}"
-                raise InternalErrorException(message, logger) from e
-            finally:
-                # clear session
-                self.tranlog_repository.set_session(session=None)
-                self.tranlog_delivery_status_repo.set_session(session=None)
+        # Manual session mgmt (no `async with`): context manager re-aborts after commit ended session — issue #96.
+        session = await self.tranlog_repository.start_transaction()
+        try:
+            self.tranlog_delivery_status_repo.set_session(session)
+            await self.tranlog_delivery_status_repo.create_status_async(
+                event_id=event_id,
+                transaction_no=tran.transaction_no,
+                payload=event_message,
+                services=event_distinations,
+            )
+            tran = await self.tranlog_repository.create_tranlog_async(tran)
+            await self.tranlog_repository.commit_transaction()
+        except Exception as e:
+            await self.tranlog_repository.abort_transaction()
+            message = f"Error creating tranlog: {e}"
+            raise InternalErrorException(message, logger) from e
+        finally:
+            # clear session
+            self.tranlog_repository.set_session(session=None)
+            self.tranlog_delivery_status_repo.set_session(session=None)
 
         # Publish tranlog
         await self._publish_tranlog_async(event_message)
@@ -682,25 +684,26 @@ class TranService:
         ]
 
         # Save tranlog to database
-        async with await self.tranlog_repository.start_transaction() as session:
-            try:
-                self.tranlog_delivery_status_repo.set_session(session)
-                await self.tranlog_delivery_status_repo.create_status_async(
-                    event_id=event_id,
-                    transaction_no=tran.transaction_no,
-                    payload=event_message,
-                    services=event_distinations,
-                )
-                tran = await self.tranlog_repository.create_tranlog_async(tran)
-                await self.tranlog_repository.commit_transaction()
-            except Exception as e:
-                await self.tranlog_repository.abort_transaction()
-                message = f"Error creating tranlog: {e}"
-                raise InternalErrorException(message, logger) from e
-            finally:
-                # clear session
-                self.tranlog_repository.set_session(session=None)
-                self.tranlog_delivery_status_repo.set_session(session=None)
+        # Manual session mgmt (no `async with`): context manager re-aborts after commit ended session — issue #96.
+        session = await self.tranlog_repository.start_transaction()
+        try:
+            self.tranlog_delivery_status_repo.set_session(session)
+            await self.tranlog_delivery_status_repo.create_status_async(
+                event_id=event_id,
+                transaction_no=tran.transaction_no,
+                payload=event_message,
+                services=event_distinations,
+            )
+            tran = await self.tranlog_repository.create_tranlog_async(tran)
+            await self.tranlog_repository.commit_transaction()
+        except Exception as e:
+            await self.tranlog_repository.abort_transaction()
+            message = f"Error creating tranlog: {e}"
+            raise InternalErrorException(message, logger) from e
+        finally:
+            # clear session
+            self.tranlog_repository.set_session(session=None)
+            self.tranlog_delivery_status_repo.set_session(session=None)
 
         # Publish tranlog
         await self._publish_tranlog_async(event_message)


### PR DESCRIPTION
## Summary

- Fixes the \`Cannot call abortTransaction after calling commitTransaction\` error observed in 60-min load tests on 8GB memory (3 occurrences out of 383,751 requests in #19).
- Replaces \`async with await ... start_transaction() as session:\` + manual \`commit_transaction()\` / \`abort_transaction()\` with manual session management. The Motor session context manager was re-aborting after \`commit_transaction()\` had already ended the session.
- Applied identically to \`create_tranlog_async\`, \`void_async\`, and \`return_async\` in \`services/cart/app/services/tran_service.py\`.

Closes #96.

## Test plan

- [x] \`tests/test_tran_service_unit_simple.py\` (3 passed)
- [x] \`tests/test_tran_service.py\` (30 passed)
- [x] \`tests/test_tran_service_status.py\` (6 passed)
- [x] \`tests/test_api_tran.py\` validation tests (14 passed)
- [x] Cart service starts up healthy with the new code (\`/health\` returns ok, all dependencies healthy)
- [ ] Optional: re-run the 60-min load test from #19 to confirm the error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)