### PR TITLE
fix(commons): TextHelper.yen() returns single minus for negatives (#111)

### DIFF
--- a/services/commons/src/kugel_common/utils/text_helper.py
+++ b/services/commons/src/kugel_common/utils/text_helper.py
@@ -60,19 +60,20 @@ class TextHelper:
     def yen(value: float, mark: str = '\\') -> str:
         """
         Format a currency value with the specified currency mark.
-        
-        Handles negative values by replacing the currency mark with a minus sign.
-        
+
+        For negative values, the currency mark is replaced with a minus
+        sign and the absolute value is formatted, so the result is
+        `-1,000` (not `\\-1,000` and not the previously-buggy `--1,000`).
+
         Args:
             value: Currency value to format
             mark: Currency symbol to use (defaults to '\' for Japanese Yen)
-            
+
         Returns:
             Formatted currency string with the appropriate symbol and comma separators
         """
-        if value < 0:
-            mark = "-"
-        return mark + TextHelper.comma(value)
+        sign = "-" if value < 0 else mark
+        return sign + TextHelper.comma(abs(value))
 
     @staticmethod
     def zero_fill(value: int, width: int) -> str:

--- a/services/commons/tests/unit/test_text_helper.py
+++ b/services/commons/tests/unit/test_text_helper.py
@@ -1,6 +1,5 @@
 # Copyright 2026 masa@kugel
 """Unit tests for kugel_common.utils.text_helper.TextHelper."""
-import pytest
 
 from kugel_common.utils.text_helper import TextHelper
 

--- a/services/commons/tests/unit/test_text_helper.py
+++ b/services/commons/tests/unit/test_text_helper.py
@@ -36,22 +36,14 @@ class TestYen:
     def test_positive_uses_default_mark(self):
         assert TextHelper.yen(1000) == "\\1,000"
 
-    @pytest.mark.xfail(
-        reason=(
-            "Bug: yen() sets mark='-' for negatives but comma() already emits a "
-            "leading '-', so the result is '--1,000'. Captured here as xfail to "
-            "document the issue without blocking CI; fix in source separately."
-        ),
-        strict=False,
-    )
-    def test_negative_uses_minus(self):
-        # Intended behavior: a single leading minus sign for negatives.
+    def test_negative_uses_single_minus(self):
+        # A single leading minus sign for negatives — no double-sign.
         assert TextHelper.yen(-1000) == "-1,000"
 
-    def test_negative_observed_behavior(self):
-        # Pinning current (buggy) behavior so a future fix is detected as a
-        # change. When yen() is fixed, update the xfail above and remove this.
-        assert TextHelper.yen(-1000) == "--1,000"
+    def test_negative_with_custom_mark_still_uses_minus(self):
+        # Negatives override the currency mark with a single minus sign,
+        # regardless of what mark was passed in.
+        assert TextHelper.yen(-500, mark="$") == "-500"
 
     def test_custom_mark(self):
         assert TextHelper.yen(500, mark="$") == "$500"


### PR DESCRIPTION
## Summary

`TextHelper.yen()` produced double-sign output (`'--1,000'`) for negative values because `comma(-1000)` already emits a leading minus, but the function then prepended another `'-'`. Fix the function to format `abs(value)` once the sign is decided.

## Before / After

```python
TextHelper.yen(1000)            # \1,000  (unchanged)
TextHelper.yen(-1000)           # before: --1,000  →  after: -1,000   ✓
TextHelper.yen(-500, mark="$")  # before: --500    →  after: -500     ✓
TextHelper.yen(0)               # \0       (unchanged)
```

## Affected

`TextHelper.yen()` is used via `AbstractReceiptData.yen()` in cart's `receipt_data_sample.py` (9 call sites) for receipts, journal text, and reports rendering negative amounts (discounts, change, return totals).

## Tests

- Drop `@pytest.mark.xfail` on `test_negative_uses_minus`, rename to `test_negative_uses_single_minus`.
- Delete `test_negative_observed_behavior` (which pinned the buggy `--1,000` output).
- Add `test_negative_with_custom_mark_still_uses_minus`.

Full suite: 2,169 unit / 153 integration passed.

## Test plan

- [x] commons unit (`pipenv run pytest -m unit`) — 304 passed
- [x] All services unit — 2,169 passed
- [x] All services integration — 153 passed

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)