### PR TITLE
fix(journal,report): catch DuplicateKeyException at pub/sub layer (#97)

### DIFF
--- a/services/journal/app/api/v1/tran.py
+++ b/services/journal/app/api/v1/tran.py
@@ -6,6 +6,7 @@ import aiohttp
 import inspect
 
 from kugel_common.database import database as db_helper
+from kugel_common.exceptions import DuplicateKeyException
 from kugel_common.schemas.api_response import ApiResponse
 from kugel_common.security import get_tenant_id_with_security_by_query_optional, verify_tenant_id
 from kugel_common.status_codes import StatusCodes
@@ -203,6 +204,27 @@ async def handle_log(request: Request, log_type: str, log_model: BaseModel, rece
 
         # Return a success response
         return {"status": "SUCCESS", "operation": f"{inspect.currentframe().f_code.co_name}"}, status.HTTP_200_OK
+    except DuplicateKeyException as e:
+        # The state-store idempotency check missed (state evicted, TTL
+        # expired, or store unreachable) and the duplicate slipped through
+        # to the DB layer, where the unique index rejected it. Treat this
+        # as success — the data already exists, no further action needed.
+        # Returning RETRY here would cause Dapr to redeliver indefinitely.
+        logger.warning(
+            f"Duplicate {log_type} caught at DB layer (idempotency state-store miss). "
+            f"event_id: {event_id}, error: {e}"
+        )
+        # Best-effort: persist the state so subsequent retries short-circuit
+        # at the state-store check.
+        try:
+            await save_state(event_id, {"event_id": event_id})
+        except Exception as save_exc:
+            logger.warning(f"Failed to save state after duplicate detection: {save_exc}")
+        return {
+            "status": "SUCCESS",
+            "message": "duplicate detected at DB layer; treated as already-processed",
+            "operation": f"{inspect.currentframe().f_code.co_name}",
+        }, status.HTTP_200_OK
     except Exception as e:
         err_message = f"Failed to receive {log_type}. message: {message}, Error: {e}"
         logger.error(err_message)

--- a/services/journal/tests/unit/test_api_tran.py
+++ b/services/journal/tests/unit/test_api_tran.py
@@ -140,6 +140,55 @@ class TestHandleTranlog:
         assert body[0]["status"] == "SUCCESS"
         mock_svc.receive_tranlog_async.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_tranlog_duplicate_at_db_layer_returns_success_not_retry(self):
+        """If DuplicateKeyException leaks past the state-store check (state
+        evicted / TTL expired), the handler must return 200 SUCCESS rather
+        than 500 RETRY — otherwise Dapr loops forever on a row that already
+        exists. See issue #97."""
+        from kugel_common.exceptions import DuplicateKeyException
+
+        mock_svc = _mock_log_service()
+        mock_svc.receive_tranlog_async.side_effect = DuplicateKeyException(
+            message="duplicate", collection_name="log_tran", key={"event_id": "evt-dup-001"}
+        )
+        app = make_app()
+        app.dependency_overrides[get_log_service_from_request] = lambda: mock_svc
+
+        with patch("app.api.v1.tran.get_state", new_callable=AsyncMock, return_value=None), \
+             patch("app.api.v1.tran.save_state", new_callable=AsyncMock, return_value=True) as save_mock, \
+             patch("app.api.v1.tran._notify_pubsub_status", new_callable=AsyncMock):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                response = await client.post(
+                    "/api/v1/tranlog",
+                    json={
+                        "data": {
+                            "event_id": "evt-dup-001",
+                            "tenant_id": "T001",
+                            "store_code": "S001",
+                            "terminal_no": 1,
+                            "transaction_no": 100,
+                            "transaction_type": 101,
+                            "business_date": "20260101",
+                            "open_counter": 1,
+                            "business_counter": 1,
+                            "generate_date_time": "20260101T120000",
+                            "receipt_no": 1,
+                            "items": [],
+                            "payments": [],
+                            "tax_details": [],
+                        }
+                    },
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        # Tuple-encoded response: [body_dict, status_code]
+        assert body[0]["status"] == "SUCCESS"
+        assert body[1] == 200
+        # Best-effort state save to short-circuit future redeliveries
+        save_mock.assert_awaited()
+
 
 # ---------------------------------------------------------------------------
 # POST /cashlog  (Dapr pub/sub)

--- a/services/report/app/api/v1/tran.py
+++ b/services/report/app/api/v1/tran.py
@@ -7,6 +7,7 @@ import inspect
 from typing import Dict, Any
 
 from kugel_common.database import database as db_helper
+from kugel_common.exceptions import DuplicateKeyException
 from kugel_common.schemas.api_response import ApiResponse
 from kugel_common.security import get_tenant_id_with_security_by_query_optional, verify_tenant_id
 from kugel_common.status_codes import StatusCodes
@@ -192,6 +193,27 @@ async def handle_log(request: Request, log_type: str, log_model: BaseModel, rece
         logger.debug(f"Processed {log_type} successfully. event_id: {event_id}, {log_type}: {log_info}")
         return {"status": "SUCCESS", "operation": f"{inspect.currentframe().f_code.co_name}"}, status.HTTP_200_OK
 
+    except DuplicateKeyException as e:
+        # The state-store idempotency check missed (state evicted, TTL
+        # expired, or store unreachable) and the duplicate slipped through
+        # to the DB layer, where the unique index rejected it. Treat this
+        # as success — the data already exists, no further action needed.
+        # Returning RETRY here would cause Dapr to redeliver indefinitely.
+        logger.warning(
+            f"Duplicate {log_type} caught at DB layer (idempotency state-store miss). "
+            f"event_id: {event_id}, error: {e}"
+        )
+        # Best-effort: persist the state so subsequent retries short-circuit
+        # at the state-store check.
+        try:
+            await state_store_manager.save_state(event_id, {"event_id": event_id})
+        except Exception as save_exc:
+            logger.warning(f"Failed to save state after duplicate detection: {save_exc}")
+        return {
+            "status": "SUCCESS",
+            "message": "duplicate detected at DB layer; treated as already-processed",
+            "operation": f"{inspect.currentframe().f_code.co_name}",
+        }, status.HTTP_200_OK
     except Exception as e:
         err_message = f"Error processing {log_type}. message: {message}, Error: {e}"
         logger.error(err_message)

--- a/services/report/tests/unit/test_api_tran.py
+++ b/services/report/tests/unit/test_api_tran.py
@@ -114,6 +114,62 @@ class TestHandleTranlog:
             )
         assert resp.status_code == 500
 
+    @pytest.mark.asyncio
+    async def test_duplicate_at_db_layer_returns_success_not_retry(self):
+        """If DuplicateKeyException leaks past the state-store check (state
+        evicted / TTL expired), the handler must return 200 SUCCESS rather
+        than 500 RETRY — otherwise Dapr loops forever on a row that already
+        exists. See issue #97."""
+        from kugel_common.exceptions import DuplicateKeyException
+
+        mock_service = AsyncMock()
+        mock_service.receive_tranlog_async.side_effect = DuplicateKeyException(
+            message="duplicate", collection_name="log_tran", key={"event_id": "evt-dup-001"}
+        )
+        app = make_app(mock_log_service=mock_service)
+
+        # state-store says "not seen" so handler proceeds to DB write,
+        # which raises DuplicateKeyException.
+        with patch(
+            "app.api.v1.tran.state_store_manager.get_state",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ), patch(
+            "app.api.v1.tran.state_store_manager.save_state",
+            new_callable=AsyncMock,
+            return_value=(True, None),
+        ) as save_mock, patch(
+            "app.api.v1.tran._notify_pubsub_status", new_callable=AsyncMock
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v1/tranlog",
+                    json={
+                        "data": {
+                            "event_id": "evt-dup-001",
+                            "tenant_id": "test-tenant",
+                            "store_code": "STORE01",
+                            "terminal_no": 1,
+                            "transaction_no": 100,
+                            "transaction_type": 101,
+                            "business_date": "20260101",
+                            "open_counter": 1,
+                            "business_counter": 1,
+                            "generate_date_time": "20260101T120000",
+                            "receipt_no": 1,
+                        }
+                    },
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Tuple-encoded response: [body_dict, status_code]
+        assert body[0]["status"] == "SUCCESS"
+        assert body[1] == 200
+        # Best-effort state save to short-circuit future redeliveries
+        save_mock.assert_awaited()
+
 
 # ---------------------------------------------------------------------------
 # handle_cashlog (pub/sub endpoint)


### PR DESCRIPTION
## Summary

When the Dapr state-store idempotency check misses (state evicted, TTL expired, or store unreachable), duplicate pub/sub messages reach the DB layer. The unique index rejects them with `DuplicateKeyException`, which the broad `except Exception` was treating as a transient failure → HTTP 500 RETRY → Dapr redelivery → **infinite loop on a row that already exists**.

## Fix

Add an explicit `except DuplicateKeyException` branch in both `handle_log()` implementations that returns **HTTP 200 SUCCESS**. The data already exists; no further action is needed.

```python
except DuplicateKeyException as e:
    logger.warning(f"Duplicate {log_type} caught at DB layer ...")
    # Best-effort: persist state so subsequent retries short-circuit
    try:
        await save_state(event_id, {"event_id": event_id})
    except Exception:
        pass
    return {"status": "SUCCESS", ...}, status.HTTP_200_OK
```

## Files

| File | Change |
|---|---|
| `services/journal/app/api/v1/tran.py` | + DuplicateKeyException import; + new except branch |
| `services/report/app/api/v1/tran.py` | + DuplicateKeyException import; + new except branch |
| `services/journal/tests/unit/test_api_tran.py` | + `test_tranlog_duplicate_at_db_layer_returns_success_not_retry` |
| `services/report/tests/unit/test_api_tran.py` | + `test_duplicate_at_db_layer_returns_success_not_retry` |

## Verification

- journal unit tier: **152 passed** (+1 new test)
- report unit tier: **207 passed** (+1 new test)
- Full unit tier: **2,171 passed** (was 2,169)
- Full integration tier: **153 passed** (unchanged)

## Test plan

- [x] Both new unit tests pass
- [x] No regression in existing unit / integration tiers
- [x] DuplicateKeyException now returns 200 SUCCESS instead of 500 RETRY

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)