### PR TITLE
fix(security): mask API keys in logs and API responses (#122)

### DIFF
--- a/services/account/Pipfile
+++ b/services/account/Pipfile
@@ -13,7 +13,7 @@ motor = "*"
 pytz = "*"
 pyjwt = "*"
 passlib = {extras = ["bcrypt"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 
 bcrypt = "==3.2.0"
 python-multipart = "*"

--- a/services/account/Pipfile.lock
+++ b/services/account/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dde19e7be8f43e9c5d1c2e1f17efee9ea4b2557bd095d1da92f5155a710382cc"
+            "sha256": "74910624cb64452022aa186cf2072b54f4a36812a5eae93b3502eae27ec33d24"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -672,9 +672,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/cart/Pipfile
+++ b/services/cart/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 pydantic-xml = {extras = ["lxml"], version = "*"}

--- a/services/cart/Pipfile.lock
+++ b/services/cart/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7b8870e038f81882c18831a790a20f6c76c09647605f05a9248b19d5218b7814"
+            "sha256": "a7a1d5d25d70810cf47050facc7221c09adae42ee117a8cb87aa704f0b3d9003"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -574,9 +574,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/commons/src/kugel_common/__about__.py
+++ b/services/commons/src/kugel_common/__about__.py
@@ -14,5 +14,5 @@
 # SPDX-FileCopyrightText: 2024-present kugel-masa <masa@kugel.cloud>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.48"
+__version__ = "0.1.49"
 

--- a/services/commons/src/kugel_common/middleware/log_requests.py
+++ b/services/commons/src/kugel_common/middleware/log_requests.py
@@ -33,6 +33,7 @@ from kugel_common.models.repositories.request_log_repository import RequestLogRe
 from kugel_common.models.documents.request_log_document import RequestLog
 from kugel_common.config.settings import settings
 from kugel_common.utils.misc import get_app_time_str
+from kugel_common.utils.log_utils import mask_api_key
 from kugel_common.middleware.request_log_buffer import get_request_log_buffer
 
 logger = getLogger(__name__)
@@ -213,16 +214,16 @@ async def _get_terminal_info(request: Request, is_terminal_service: bool = False
     terminal_id = None
 
     api_key = request.headers.get("X-API-Key")
-    logger.debug(f"api_key: {api_key}")
+    logger.debug(f"api_key: {mask_api_key(api_key)}")
     if api_key is not None:
         terminal_id = request.query_params.get("terminal_id")
         logger.debug(f"query_params terminal_id: {terminal_id}")
         if not terminal_id:
-            terminal_id = request.path_params.get("terminal_id") 
+            terminal_id = request.path_params.get("terminal_id")
             logger.debug(f"path_params terminal_id: {terminal_id}")
 
     if terminal_id and api_key:
-        logger.debug(f"terminal_id: {terminal_id}, api_key")
+        logger.debug(f"terminal_id: {terminal_id}, api_key: {mask_api_key(api_key)}")
         terminal_info = await get_terminal_info(terminal_id, api_key, is_terminal_service=is_terminal_service)
 
     logger.debug(f"terminal_info: {terminal_info}")

--- a/services/commons/src/kugel_common/security.py
+++ b/services/commons/src/kugel_common/security.py
@@ -24,6 +24,7 @@ from kugel_common.database import database as db_helper
 from kugel_common.models.documents.terminal_info_document import TerminalInfoDocument
 from kugel_common.models.documents.staff_master_document import StaffMasterDocument
 from kugel_common.utils.http_client_helper import get_pooled_client, HttpClientError
+from kugel_common.utils.log_utils import mask_dict_api_key
 
 logger = getLogger(__name__)
 
@@ -257,7 +258,7 @@ async def get_terminal_info_for_terminal_service(
     db = await db_helper.get_db_async(f"{settings.DB_NAME_PREFIX}_{tenant_id}")
     collection = db.get_collection(settings.DB_COLLECTION_NAME_TERMINAL_INFO)
     terminal_dict =  await collection.find_one({"terminal_id": terminal_id})
-    logger.debug(f"TerminalInfo: {terminal_dict}")
+    logger.debug(f"TerminalInfo: {mask_dict_api_key(terminal_dict) if terminal_dict else None}")
     # verify api_key
     if (terminal_dict is None) or (terminal_dict.get("api_key") != api_key):
         if api_key != settings.PUBSUB_NOTIFY_API_KEY:

--- a/services/commons/src/kugel_common/utils/log_utils.py
+++ b/services/commons/src/kugel_common/utils/log_utils.py
@@ -36,15 +36,20 @@ def mask_api_key(api_key: Optional[str]) -> str:
     return f"{api_key[:4]}...{api_key[-4:]}"
 
 
-def mask_dict_api_key(data: Dict[str, Any]) -> Dict[str, Any]:
+def mask_dict_api_key(data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """
     Mask api_key field in dictionary for safe logging.
 
+    Only the top-level keys "api_key" / "API_KEY" are masked; nested
+    dictionaries are not traversed (this is a shallow copy). All current
+    callers pass flat documents from MongoDB, so this is sufficient.
+
     Args:
-        data: Dictionary that may contain api_key field
+        data: Dictionary that may contain api_key field, or None
 
     Returns:
-        Dictionary with masked api_key (original dict is not modified)
+        Dictionary with masked api_key (original dict is not modified),
+        or None if input was None/empty.
     """
     if not data:
         return data

--- a/services/commons/src/kugel_common/utils/log_utils.py
+++ b/services/commons/src/kugel_common/utils/log_utils.py
@@ -1,0 +1,63 @@
+"""
+Logging utility functions for masking sensitive information.
+"""
+import os
+from typing import Any, Dict, Optional
+
+
+def mask_api_key(api_key: Optional[str]) -> str:
+    """
+    Mask API key for safe logging.
+
+    Args:
+        api_key: The API key to mask
+
+    Returns:
+        Masked API key string
+
+    Examples:
+        - None or empty -> "****"
+        - Short key (<=8 chars) -> "****"
+        - Long key -> "sk_l...5678" (first 4...last 4)
+    """
+    # Check if masking is disabled for testing
+    if os.environ.get("DISABLE_API_KEY_MASKING") == "True":
+        return api_key if api_key else "****"
+
+    if not api_key:
+        return "****"
+
+    key_length = len(api_key)
+
+    if key_length <= 8:
+        return "****"
+
+    # For longer keys, show first 4 and last 4 characters
+    return f"{api_key[:4]}...{api_key[-4:]}"
+
+
+def mask_dict_api_key(data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Mask api_key field in dictionary for safe logging.
+
+    Args:
+        data: Dictionary that may contain api_key field
+
+    Returns:
+        Dictionary with masked api_key (original dict is not modified)
+    """
+    if not data:
+        return data
+
+    # Create a copy to avoid modifying the original
+    masked_data = data.copy()
+
+    # Mask api_key field if it exists
+    if "api_key" in masked_data:
+        masked_data["api_key"] = mask_api_key(masked_data["api_key"])
+
+    # Also check for API_KEY (uppercase variant)
+    if "API_KEY" in masked_data:
+        masked_data["API_KEY"] = mask_api_key(masked_data["API_KEY"])
+
+    return masked_data

--- a/services/commons/tests/unit/test_log_utils.py
+++ b/services/commons/tests/unit/test_log_utils.py
@@ -1,0 +1,109 @@
+"""Unit tests for kugel_common.utils.log_utils."""
+import os
+
+import pytest
+
+from kugel_common.utils.log_utils import mask_api_key, mask_dict_api_key
+
+
+@pytest.fixture(autouse=True)
+def _ensure_masking_enabled(monkeypatch):
+    """Default: masking enabled. Tests that need it disabled override locally."""
+    monkeypatch.delenv("DISABLE_API_KEY_MASKING", raising=False)
+
+
+class TestMaskApiKey:
+    def test_none_returns_stars(self):
+        assert mask_api_key(None) == "****"
+
+    def test_empty_string_returns_stars(self):
+        assert mask_api_key("") == "****"
+
+    def test_short_key_returns_stars(self):
+        # Boundary: 8 chars is treated as short
+        assert mask_api_key("12345678") == "****"
+
+    def test_one_char_returns_stars(self):
+        assert mask_api_key("a") == "****"
+
+    def test_nine_char_key_truncated(self):
+        # First boundary case where masking reveals first4...last4
+        assert mask_api_key("abcdefghi") == "abcd...fghi"
+
+    def test_long_key_truncated(self):
+        assert mask_api_key("abcd1234efgh5678") == "abcd...5678"
+
+    def test_very_long_key_truncated(self):
+        key = "sk_live_" + "x" * 40 + "_end1234"
+        assert mask_api_key(key) == "sk_l...1234"
+
+
+class TestMaskApiKeyDisabled:
+    """When DISABLE_API_KEY_MASKING=True, the original key passes through."""
+
+    def test_long_key_unmasked(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "True")
+        assert mask_api_key("abcd1234efgh5678") == "abcd1234efgh5678"
+
+    def test_short_key_unmasked(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "True")
+        assert mask_api_key("short") == "short"
+
+    def test_none_still_returns_stars(self, monkeypatch):
+        # Even when masking is disabled, None has no plaintext to surface
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "True")
+        assert mask_api_key(None) == "****"
+
+    def test_other_truthy_env_value_does_not_disable(self, monkeypatch):
+        # Only the literal string "True" disables masking
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "true")
+        assert mask_api_key("abcd1234efgh5678") == "abcd...5678"
+
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "1")
+        assert mask_api_key("abcd1234efgh5678") == "abcd...5678"
+
+
+class TestMaskDictApiKey:
+    def test_none_returns_none(self):
+        assert mask_dict_api_key(None) is None
+
+    def test_empty_dict_returns_empty(self):
+        assert mask_dict_api_key({}) == {}
+
+    def test_dict_without_api_key_unchanged(self):
+        data = {"name": "alice", "tenant_id": "T001"}
+        assert mask_dict_api_key(data) == data
+
+    def test_lowercase_api_key_masked(self):
+        result = mask_dict_api_key({"api_key": "abcd1234efgh5678", "other": "x"})
+        assert result == {"api_key": "abcd...5678", "other": "x"}
+
+    def test_uppercase_api_key_masked(self):
+        result = mask_dict_api_key({"API_KEY": "abcd1234efgh5678"})
+        assert result == {"API_KEY": "abcd...5678"}
+
+    def test_both_variants_masked(self):
+        result = mask_dict_api_key(
+            {"api_key": "abcd1234efgh5678", "API_KEY": "qrst1234uvwx5678"}
+        )
+        assert result == {"api_key": "abcd...5678", "API_KEY": "qrst...5678"}
+
+    def test_original_dict_not_mutated(self):
+        # Critical: callers in security.py rely on the original dict's
+        # api_key being intact for the post-log auth comparison.
+        original = {"api_key": "abcd1234efgh5678", "name": "alice"}
+        mask_dict_api_key(original)
+        assert original == {"api_key": "abcd1234efgh5678", "name": "alice"}
+
+    def test_short_key_in_dict_masked_to_stars(self):
+        result = mask_dict_api_key({"api_key": "short"})
+        assert result == {"api_key": "****"}
+
+    def test_none_value_in_dict_masked_to_stars(self):
+        result = mask_dict_api_key({"api_key": None})
+        assert result == {"api_key": "****"}
+
+    def test_disabled_passes_through_dict(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_API_KEY_MASKING", "True")
+        result = mask_dict_api_key({"api_key": "abcd1234efgh5678"})
+        assert result == {"api_key": "abcd1234efgh5678"}

--- a/services/docker-compose.override.yaml
+++ b/services/docker-compose.override.yaml
@@ -23,7 +23,7 @@ services:
       - BASE_URL_JOURNAL=http://journal:8000/api/v1
       - BASE_URL_TERMINAL=http://terminal:8000/api/v1
       - BASE_URL_STOCK=http://stock:8000/api/v1
-      - DISABLE_API_KEY_MASKING=False
+      - DISABLE_API_KEY_MASKING=True
     depends_on:
       mongodb:
         condition: service_healthy

--- a/services/journal/Pipfile
+++ b/services/journal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 
 httpx = "*"
 aiohttp = "*"

--- a/services/journal/Pipfile.lock
+++ b/services/journal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "338fefc6c1b37f9f55c5754f5bc5d561f51a3e1290a85379901aafdf0d951b34"
+            "sha256": "1d87c77e810d761121a82bb11c6bc3e8a4fecfda4b38cd762fc8ccaf7bb2bffe"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -565,9 +565,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/master-data/Pipfile
+++ b/services/master-data/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 httpx = "*"
 pydantic-xml = {extras = ["lxml"], version = "*"}
 lxml = "*"

--- a/services/master-data/Pipfile.lock
+++ b/services/master-data/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0f3b10d956de1fe30fe5b5a63a89431df47c31731e49e1a7cddcf04ffddfadcf"
+            "sha256": "b3c797c279b8f064376f94260ab3889caa99bcd68ab0743bdb322fc998782f55"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -278,9 +278,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/report/Pipfile
+++ b/services/report/Pipfile
@@ -15,7 +15,7 @@ pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
 pydantic-xml = {extras = ["lxml"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 lxml = "*"
 wcwidth = "*"
 debugpy = "*"

--- a/services/report/Pipfile.lock
+++ b/services/report/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "12b2489c12c8155cef34093b4e2f97fd754557e99b0f991d79d49e17b2ba527e"
+            "sha256": "badad7c1f3f70ae6d67899e73e8aeacb4f44d2f15f635833aac84467cd55bba4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -700,9 +700,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/stock/Pipfile
+++ b/services/stock/Pipfile
@@ -15,7 +15,7 @@ pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
 pydantic-xml = {extras = ["lxml"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 lxml = "*"
 wcwidth = "*"
 debugpy = "*"

--- a/services/stock/Pipfile.lock
+++ b/services/stock/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b504a1dd1b72305e44ed48b71cdfbeb2f731867b2e352038bc1777b304df60df"
+            "sha256": "8a3f7e77f208c403a2ad028b1060e0ab76a9e2dd8ca808e4674e473b9b93ec34"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -709,9 +709,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/terminal/Pipfile
+++ b/services/terminal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.48-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.49-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 pydantic-xml = {extras = ["lxml"], version = "*"}

--- a/services/terminal/Pipfile.lock
+++ b/services/terminal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "84db003219cedfa2dbd0c914e8062d0c49a804d9c0a1e4e17386a9033037a780"
+            "sha256": "d5056db746fff4d54bab4869030a4562946497dcb611e61539c443f415cec7cb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -574,9 +574,9 @@
             "version": "==3.13"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.48-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.49-py3-none-any.whl",
             "hashes": [
-                "sha256:32540c75b05d4c01140762e5169c49358eb44d9b3e92547d85862a753284da4d"
+                "sha256:e88b44ccb868a07cf475885abdec882cc8ef3a65ef98f1669bdd9b5dbab19124"
             ]
         },
         "lxml": {

--- a/services/terminal/app/api/common/schemas_transformer.py
+++ b/services/terminal/app/api/common/schemas_transformer.py
@@ -1,5 +1,7 @@
 # Copyright 2025 masa@kugel  # # Licensed under the Apache License, Version 2.0 (the "License");  # you may not use this file except in compliance with the License.  # You may obtain a copy of the License at  # #     http://www.apache.org/licenses/LICENSE-2.0  # # Unless required by applicable law or agreed to in writing, software  # distributed under the License is distributed on an "AS IS" BASIS,  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  # See the License for the specific language governing permissions and  # limitations under the License.
 from logging import getLogger
+import os
+from kugel_common.utils.log_utils import mask_api_key
 from app.models.documents.terminal_info_document import TerminalInfoDocument
 from app.models.documents.tenant_info_document import TenantInfoDocument, StoreInfo
 from app.models.documents.open_close_log import OpenCloseLog
@@ -30,7 +32,7 @@ class SchemasTransformer:
             business_counter=terminal_info.business_counter,
             initial_amount=terminal_info.initial_amount,
             physical_amount=terminal_info.physical_amount,
-            api_key=terminal_info.api_key,
+            api_key=terminal_info.api_key if os.environ.get("DISABLE_API_KEY_MASKING") == "True" else mask_api_key(terminal_info.api_key),
             entry_datetime=terminal_info.created_at.strftime("%Y-%m-%d %H:%M:%S") if terminal_info.created_at else None,
             last_update_datetime=(
                 terminal_info.updated_at.strftime("%Y-%m-%d %H:%M:%S") if terminal_info.updated_at else None

--- a/services/terminal/app/api/common/schemas_transformer.py
+++ b/services/terminal/app/api/common/schemas_transformer.py
@@ -1,6 +1,5 @@
 # Copyright 2025 masa@kugel  # # Licensed under the Apache License, Version 2.0 (the "License");  # you may not use this file except in compliance with the License.  # You may obtain a copy of the License at  # #     http://www.apache.org/licenses/LICENSE-2.0  # # Unless required by applicable law or agreed to in writing, software  # distributed under the License is distributed on an "AS IS" BASIS,  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  # See the License for the specific language governing permissions and  # limitations under the License.
 from logging import getLogger
-import os
 from kugel_common.utils.log_utils import mask_api_key
 from app.models.documents.terminal_info_document import TerminalInfoDocument
 from app.models.documents.tenant_info_document import TenantInfoDocument, StoreInfo
@@ -32,7 +31,7 @@ class SchemasTransformer:
             business_counter=terminal_info.business_counter,
             initial_amount=terminal_info.initial_amount,
             physical_amount=terminal_info.physical_amount,
-            api_key=terminal_info.api_key if os.environ.get("DISABLE_API_KEY_MASKING") == "True" else mask_api_key(terminal_info.api_key),
+            api_key=mask_api_key(terminal_info.api_key),
             entry_datetime=terminal_info.created_at.strftime("%Y-%m-%d %H:%M:%S") if terminal_info.created_at else None,
             last_update_datetime=(
                 terminal_info.updated_at.strftime("%Y-%m-%d %H:%M:%S") if terminal_info.updated_at else None

--- a/services/terminal/tests/conftest.py
+++ b/services/terminal/tests/conftest.py
@@ -122,6 +122,9 @@ def set_env_vars():
     ensure_admin_user_exists(tenant_id, account_base_url)
 
     os.environ["DB_NAME_PREFIX"] = "db_terminal"
+    # Tests need the unmasked API key from terminal API responses to authenticate
+    # subsequent in-process requests; docker compose sets the same flag at runtime.
+    os.environ["DISABLE_API_KEY_MASKING"] = "True"
 
     from kugel_common.database import database as db_helper
 
@@ -141,6 +144,7 @@ def set_env_vars():
     yield
 
     del os.environ["DB_NAME_PREFIX"]
+    del os.environ["DISABLE_API_KEY_MASKING"]
     del os.environ["TOKEN_URL"]
     del os.environ["BASE_URL_TERMINAL"]
     del os.environ["BASE_URL_MASTER_DATA"]

--- a/services/terminal/tests/integration/conftest.py
+++ b/services/terminal/tests/integration/conftest.py
@@ -31,6 +31,9 @@ def set_env_vars():
     load_dotenv(dotenv_path=os.path.join(ROOT_DIR, ".env.test"), override=True)
 
     os.environ.setdefault("DB_NAME_PREFIX", "db_terminal")
+    # Tests need the unmasked API key from terminal API responses to authenticate
+    # subsequent in-process requests; docker compose sets the same flag at runtime.
+    os.environ.setdefault("DISABLE_API_KEY_MASKING", "True")
     os.environ.setdefault("STORE_CODE", "5678")
     os.environ.setdefault("TERMINAL_ID", f"{os.environ.get('TENANT_ID', 'T9999')}-5678-9")
     # Match the kugel_common Settings defaults (which include the /api/v1


### PR DESCRIPTION
## Summary

Ports the urgent security fix from private repo PR #32. `DISABLE_API_KEY_MASKING` env var was already wired in `services/docker-compose.override.yaml`, but the consuming masking implementation was missing — so API keys were emitted in plaintext to debug logs and the terminal API response.

## Changes

### Core fix
- **New** `services/commons/src/kugel_common/utils/log_utils.py`
  - `mask_api_key()`: short keys (≤8 chars) → `****`; longer keys → `first4...last4`
  - `mask_dict_api_key()`: masks `api_key` / `API_KEY` in dicts (shallow, non-mutating)
  - `DISABLE_API_KEY_MASKING=True` env disables masking for tests
- `kugel_common/middleware/log_requests.py`: mask `X-API-Key` in `_get_terminal_info` debug log
- `kugel_common/security.py`: mask api_key in `TerminalInfo` debug log inside `get_terminal_info_for_terminal_service`
- `terminal/app/api/common/schemas_transformer.py`: mask `api_key` in `transform_terminal` response — delegates env-var handling to `mask_api_key()` (no duplicate check at the call site)
- `services/docker-compose.override.yaml`: switch **terminal** from `DISABLE_API_KEY_MASKING=False` to `True`. Without this, `cart/tests/conftest.py` (which fetches the api key from the terminal response) breaks once masking lands.
- Bump `kugel_common` to **0.1.49** and propagate to all 7 services (Pipfile + Pipfile.lock)

### Tests
- `services/commons/tests/unit/test_log_utils.py` (21 cases): boundary inputs (None / empty / 8-char / 9-char / long), env-var override (`True` only — not `true`/`1`), uppercase/lowercase dict keys, **non-mutation guarantee** that `security.py` relies on for the post-log auth comparison.
- `services/terminal/tests/conftest.py` and `tests/integration/conftest.py`: set `DISABLE_API_KEY_MASKING=True` so ASGI in-process integration tests can read back the unmasked key from terminal API responses (docker compose already sets the same flag at runtime, so e2e is unaffected).

## Security impact

- API keys no longer appear in logs (production log access no longer leaks credentials)
- Terminal API responses no longer return plaintext api_key (clients see masked form)
- Authentication is unaffected — masking is applied only to display/log paths; the original value is used for the auth comparison

## Test plan

- [x] `cd services/commons && pipenv run pytest tests/unit/test_log_utils.py -v` → 21 passed
- [x] `./scripts/run_unit_tests.sh` → 8/8 services passed
- [x] `./scripts/run_integration_tests.sh` → 7/7 services passed
- [x] `./scripts/run_e2e_tests.sh` (after rebuild + restart of terminal image) → 8/8 services + cross-service passed

## Reference

- Private repo commit: 3a5585a (PR #32)
- Issue: #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)