### PR TITLE
fix(cart): repair cart integration tier (master_cache_backend + API_KEY)

### DIFF
--- a/services/cart/tests/integration/conftest.py
+++ b/services/cart/tests/integration/conftest.py
@@ -27,6 +27,11 @@ import respx
 from httpx import AsyncClient, ASGITransport
 
 
+# Single source of truth for the API key shared by the mock terminal payload
+# (the apiKey it returns) and the X-API-KEY header the tests send.
+TEST_API_KEY = "test-api-key-12345"
+
+
 # ---------------------------------------------------------------------------
 # Synthetic item / payment data used by the gRPC + HTTP mocks
 # ---------------------------------------------------------------------------
@@ -169,7 +174,7 @@ def terminal_jwt():
 
 @pytest.fixture
 def api_key():
-    return "test-api-key-12345"
+    return TEST_API_KEY
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +246,7 @@ def mock_outbound(admin_token, mock_grpc_item_lookup):
                 "initialAmount": 50000.0,
                 "physicalAmount": None,
                 "staff": {"staffId": "S001", "staffName": "Staff1", "staffPin": "1234"},
-                "apiKey": "test-api-key-12345",
+                "apiKey": TEST_API_KEY,
             },
         }
         respx_mock.get(

--- a/services/cart/tests/integration/conftest.py
+++ b/services/cart/tests/integration/conftest.py
@@ -372,6 +372,13 @@ def mock_outbound(admin_token, mock_grpc_item_lookup):
 async def http_client(_reset_db_client_per_test, mock_outbound):
     """In-process AsyncClient bound to the cart FastAPI app."""
     from app.main import app
+    from kugel_common.utils.cache.in_memory_cache_backend import InMemoryCacheBackend
+
+    # ASGITransport does not run the app lifespan, so app.state.master_cache_backend
+    # (normally created in main.py's lifespan) is absent. The DI layer reads it on
+    # every cart/tran request, so provide an in-process backend here. A fresh
+    # instance per test keeps the cache isolated between tests.
+    app.state.master_cache_backend = InMemoryCacheBackend()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/services/cart/tests/integration/test_payment_cashless_error.py
+++ b/services/cart/tests/integration/test_payment_cashless_error.py
@@ -6,13 +6,12 @@ from fastapi import status
 
 
 @pytest.mark.asyncio
-async def test_cashless_payment_with_detailed_receipt_info(http_client):
+async def test_cashless_payment_with_detailed_receipt_info(http_client, api_key):
     """Test cashless payment with detailed receipt info that causes 500 error"""
     
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {
@@ -165,13 +164,12 @@ async def test_cashless_payment_with_detailed_receipt_info(http_client):
 
 
 @pytest.mark.asyncio
-async def test_cashless_payment_simple(http_client):
+async def test_cashless_payment_simple(http_client, api_key):
     """Test cashless payment with minimal detail to isolate the issue"""
     
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {
@@ -239,13 +237,12 @@ async def test_cashless_payment_simple(http_client):
 
 
 @pytest.mark.asyncio
-async def test_cashless_payment_with_wrong_case(http_client):
+async def test_cashless_payment_with_wrong_case(http_client, api_key):
     """Test cashless payment with camelCase field names (original request format)"""
     
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {

--- a/services/cart/tests/integration/test_payment_cashless_error.py
+++ b/services/cart/tests/integration/test_payment_cashless_error.py
@@ -12,7 +12,7 @@ async def test_cashless_payment_with_detailed_receipt_info(http_client):
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = os.environ.get("API_KEY")
+    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {
@@ -171,7 +171,7 @@ async def test_cashless_payment_simple(http_client):
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = os.environ.get("API_KEY")
+    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {
@@ -245,7 +245,7 @@ async def test_cashless_payment_with_wrong_case(http_client):
     # Environment variables
     tenant_id = os.environ.get("TENANT_ID")
     terminal_id = os.environ.get("TERMINAL_ID")
-    api_key = os.environ.get("API_KEY")
+    api_key = "test-api-key-12345"  # matches the mock terminal apiKey (integration tier sets no API_KEY env)
     
     # Headers
     headers = {


### PR DESCRIPTION
## Summary

Repairs two independent breakages in the cart **integration** test tier, surfaced by a full unit+integration+e2e run on `main` (the integration tier was not run after the master-data cache work in #126).

## Root causes & fixes

1. **#126 regression (HTTP 500).** The master-data cache DI reads `request.app.state.master_cache_backend` on every cart/tran request, but it is only created in `main.py`'s `lifespan`. The integration `http_client` fixture drives the app via `ASGITransport`, which does **not** run the lifespan, so the attribute was missing → `'State' object has no attribute 'master_cache_backend'`. Fix: set a fresh `InMemoryCacheBackend` on `app.state` in the fixture (a new instance per test keeps the cache isolated).

2. **Pre-existing test bug (httpx TypeError).** `test_payment_cashless_error.py` built the `X-API-KEY` header from the e2e-style `os.environ.get("API_KEY")`, but the integration tier never sets that env var, so the header value was `None`. Fix: use the hardcoded `"test-api-key-12345"` that matches the mock terminal apiKey, consistent with `test_cart_operations.py`.

Both are test-only changes (conftest + a test file); no production code is touched.

## Test plan

- [x] cart integration: 26/26 pass
- [x] all-services integration: 7/7 pass
- [x] full `run_all_tests.sh` on the live stack: unit 8/8, integration 7/7, e2e 8/8 suites green

Refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)