### PR TITLE
refactor(cart): make master-data cache base class portable (decouple from cart settings)

### DIFF
--- a/services/cart/app/api/v1/cache.py
+++ b/services/cart/app/api/v1/cache.py
@@ -60,6 +60,21 @@ async def invalidate_master_data_cache(
     username = current_user.get("username")
 
     backend = request.app.state.master_cache_backend
+    if backend is None:
+        # Caching is disabled — nothing to invalidate.
+        return ApiResponse(
+            success=True,
+            code=status.HTTP_200_OK,
+            message="Master-data cache is disabled; nothing to invalidate",
+            data={
+                "cache_type": "master_data",
+                "tenant_id": tenant_id,
+                "namespace": namespace,
+                "store_code": store_code,
+                "new_generation": None,
+            },
+        )
+
     gen_key = AbstractMasterDataRepository.build_generation_key(
         tenant_id, store_code, namespace
     )

--- a/services/cart/app/dependencies/get_cart_service.py
+++ b/services/cart/app/dependencies/get_cart_service.py
@@ -22,7 +22,7 @@ from app.config.settings import settings
 logger = getLogger(__name__)
 
 
-def _get_master_cache_backend(request: Request) -> AbstractCacheBackend:
+def _get_master_cache_backend(request: Request) -> AbstractCacheBackend | None:
     """Retrieve the singleton master-data cache backend bound at app startup."""
     return request.app.state.master_cache_backend
 
@@ -76,7 +76,7 @@ async def get_cart_service_with_cart_id_async(
 async def __get_cart_service_async(
     terminal_info: TerminalInfoDocument,
     cart_id: str = None,
-    cache_backend: AbstractCacheBackend = None,
+    cache_backend: AbstractCacheBackend | None = None,
 ) -> CartService:
     """
     Internal helper function to create a properly configured cart service.

--- a/services/cart/app/main.py
+++ b/services/cart/app/main.py
@@ -37,19 +37,26 @@ from app.cron.republish_undelivery_message import (
 async def lifespan(app: FastAPI):
     await startup_event()
     # Build the master-data cache backend once and keep it on app.state so the
-    # DI layer can share a single DaprClientHelper across all requests.
+    # DI layer can share a single DaprClientHelper across all requests. When
+    # caching is disabled, expose None so repositories bypass the cache (the
+    # enable/disable decision lives here, keeping the repository base class free
+    # of any app-specific config).
     from kugel_common.utils.cache.dapr_state_cache_backend import (
         DaprStateCacheBackend,
     )
     from app.config.settings_cart import cart_settings
 
-    app.state.master_cache_backend = DaprStateCacheBackend(
-        store_name=cart_settings.MASTER_DATA_CACHE_STATE_STORE
-    )
-    logger.info(
-        "master-data cache backend initialized: store=%s",
-        cart_settings.MASTER_DATA_CACHE_STATE_STORE,
-    )
+    if cart_settings.MASTER_DATA_CACHE_ENABLED:
+        app.state.master_cache_backend = DaprStateCacheBackend(
+            store_name=cart_settings.MASTER_DATA_CACHE_STATE_STORE
+        )
+        logger.info(
+            "master-data cache backend initialized: store=%s",
+            cart_settings.MASTER_DATA_CACHE_STATE_STORE,
+        )
+    else:
+        app.state.master_cache_backend = None
+        logger.info("master-data cache disabled (MASTER_DATA_CACHE_ENABLED=False)")
     try:
         yield
     finally:

--- a/services/cart/app/models/repositories/abstract_master_data_repository.py
+++ b/services/cart/app/models/repositories/abstract_master_data_repository.py
@@ -49,8 +49,6 @@ from kugel_common.models.documents.base_document_model import BaseDocumentModel
 from kugel_common.models.documents.terminal_info_document import TerminalInfoDocument
 from kugel_common.utils.cache.cache_backend import AbstractCacheBackend
 
-from app.config.settings_cart import cart_settings
-
 logger = logging.getLogger(__name__)
 
 TDoc = TypeVar("TDoc", bound=BaseDocumentModel)
@@ -74,9 +72,13 @@ class AbstractMasterDataRepository(Generic[TDoc], ABC):
         self,
         tenant_id: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: Optional[AbstractCacheBackend],
         store_code: Optional[str] = None,
     ) -> None:
+        # cache_backend is None when caching is globally disabled; in that case
+        # every lookup bypasses the cache and goes straight to the source. This
+        # keeps the base class free of any app-specific config import — the
+        # enable/disable decision is made where the backend is constructed.
         self.tenant_id = tenant_id
         self.terminal_info = terminal_info
         self.cache_backend = cache_backend
@@ -136,8 +138,8 @@ class AbstractMasterDataRepository(Generic[TDoc], ABC):
         store_code_override: Optional[str] = None,
         entry_kind: str = _ENTRY_ONE,
     ) -> None:
-        """Remove a single cache entry. Safe under backend failure."""
-        if not cart_settings.MASTER_DATA_CACHE_ENABLED:
+        """Remove a single cache entry. Safe under backend failure / disabled cache."""
+        if self.cache_backend is None:
             return
         effective_store = self._resolve_store_code(store_code_override)
         generation = await self._get_generation(effective_store)
@@ -154,7 +156,7 @@ class AbstractMasterDataRepository(Generic[TDoc], ABC):
         Invalidate every cache entry in this (tenant, store, namespace) scope
         by atomically bumping the generation counter.
         """
-        if not cart_settings.MASTER_DATA_CACHE_ENABLED:
+        if self.cache_backend is None:
             return
         effective_store = self._resolve_store_code(store_code_override=None)
         new_gen = await self._bump_generation(effective_store)
@@ -274,8 +276,8 @@ class AbstractMasterDataRepository(Generic[TDoc], ABC):
         fetcher: Optional[Callable[[], Awaitable[Any]]],
         list_mode: bool,
     ) -> Any:
-        # Global cache disable: bypass entirely and call the source.
-        if not cart_settings.MASTER_DATA_CACHE_ENABLED:
+        # No backend (caching disabled): bypass entirely and call the source.
+        if self.cache_backend is None:
             return await self._invoke_fetch(logical_key, fetcher, list_mode)
 
         effective_store = self._resolve_store_code(store_code_override)

--- a/services/cart/app/models/repositories/item_master_grpc_repository.py
+++ b/services/cart/app/models/repositories/item_master_grpc_repository.py
@@ -45,7 +45,7 @@ class ItemMasterGrpcRepository(AbstractMasterDataRepository[ItemMasterDocument])
         tenant_id: str,
         store_code: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: AbstractCacheBackend | None,
     ):
         super().__init__(
             tenant_id=tenant_id,

--- a/services/cart/app/models/repositories/item_master_repository_factory.py
+++ b/services/cart/app/models/repositories/item_master_repository_factory.py
@@ -32,7 +32,7 @@ def create_item_master_repository(
     tenant_id: str,
     store_code: str,
     terminal_info: TerminalInfoDocument,
-    cache_backend: AbstractCacheBackend,
+    cache_backend: AbstractCacheBackend | None,
 ) -> AbstractMasterDataRepository[ItemMasterDocument]:
     """Return the configured item master repository (HTTP or gRPC).
 

--- a/services/cart/app/models/repositories/item_master_web_repository.py
+++ b/services/cart/app/models/repositories/item_master_web_repository.py
@@ -41,7 +41,7 @@ class ItemMasterWebRepository(AbstractMasterDataRepository[ItemMasterDocument]):
         tenant_id: str,
         store_code: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: AbstractCacheBackend | None,
     ):
         super().__init__(
             tenant_id=tenant_id,

--- a/services/cart/app/models/repositories/payment_master_web_repository.py
+++ b/services/cart/app/models/repositories/payment_master_web_repository.py
@@ -36,7 +36,7 @@ class PaymentMasterWebRepository(AbstractMasterDataRepository[PaymentMasterDocum
         self,
         tenant_id: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: AbstractCacheBackend | None,
     ):
         super().__init__(
             tenant_id=tenant_id,

--- a/services/cart/app/models/repositories/promotion_master_web_repository.py
+++ b/services/cart/app/models/repositories/promotion_master_web_repository.py
@@ -37,7 +37,7 @@ class PromotionMasterWebRepository(AbstractMasterDataRepository[PromotionMasterD
         self,
         tenant_id: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: AbstractCacheBackend | None,
     ):
         # store_code lives on the call (and on terminal_info as a fallback for
         # the business "use my terminal's store when omitted" convention);

--- a/services/cart/app/models/repositories/settings_master_web_repository.py
+++ b/services/cart/app/models/repositories/settings_master_web_repository.py
@@ -37,7 +37,7 @@ class SettingsMasterWebRepository(AbstractMasterDataRepository[SettingsMasterDoc
         self,
         tenant_id: str,
         terminal_info: TerminalInfoDocument,
-        cache_backend: AbstractCacheBackend,
+        cache_backend: Optional[AbstractCacheBackend],
         store_code: Optional[str] = None,
         terminal_no: Optional[int] = None,
     ):

--- a/services/cart/tests/integration/test_cart_operations.py
+++ b/services/cart/tests/integration/test_cart_operations.py
@@ -359,3 +359,29 @@ async def test_delivery_status_requires_pubsub_auth(http_client, admin_header):
         headers=admin_header,
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
+
+
+@pytest.mark.asyncio
+async def test_cart_flow_with_cache_disabled(http_client):
+    """FR-008 end-to-end: with the master-data cache disabled (backend None),
+    cart create + item add + subtotal still succeed via direct master-data
+    fetch through the real factory / repositories / DI. Guards the None path
+    that production takes when MASTER_DATA_CACHE_ENABLED=False (the abstract
+    base is unit-tested with None, but this exercises the concrete stack)."""
+    from app.main import app
+
+    # The http_client fixture set an InMemoryCacheBackend; simulate the
+    # disabled configuration (lifespan would set None). The next test's
+    # fixture re-sets a fresh backend, so this does not leak.
+    app.state.master_cache_backend = None
+
+    terminal_id = f"{os.environ.get('TENANT_ID')}-5678-9"
+    headers = _api_headers()
+    cart_id = await _create_cart(http_client, headers, terminal_id)
+    await _add_item(http_client, headers, terminal_id, cart_id)
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/subtotal?terminal_id={terminal_id}",
+        headers=headers,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text

--- a/services/cart/tests/unit/repositories/test_abstract_master_data_repository.py
+++ b/services/cart/tests/unit/repositories/test_abstract_master_data_repository.py
@@ -13,7 +13,6 @@ from kugel_common.exceptions.repository_exceptions import NotFoundException
 from kugel_common.models.documents.base_document_model import BaseDocumentModel
 from kugel_common.utils.cache.in_memory_cache_backend import InMemoryCacheBackend
 
-from app.config.settings_cart import cart_settings
 from app.models.repositories.abstract_master_data_repository import (
     AbstractMasterDataRepository,
 )
@@ -317,15 +316,12 @@ class TestTenantAndStoreIsolation:
 
 @pytest.mark.asyncio
 class TestGlobalSwitch:
-    async def test_disabled_cache_always_calls_source(self, cache, monkeypatch):
-        """FR-008: MASTER_DATA_CACHE_ENABLED=False bypasses cache entirely."""
-        monkeypatch.setattr(cart_settings, "MASTER_DATA_CACHE_ENABLED", False)
-        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=cache)
+    async def test_disabled_cache_always_calls_source(self):
+        """FR-008: a None backend (caching disabled) bypasses cache entirely."""
+        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=None)
         for _ in range(3):
             await repo.get_or_fetch_one("X")
         assert repo.fetch_calls == 3
-        # Nothing was written to the backend store.
-        assert len(cache._store) == 0
 
 
 @pytest.mark.asyncio
@@ -362,34 +358,14 @@ class TestInvalidationSafety:
             for r in caplog.records
         )
 
-    async def test_invalidate_is_noop_when_cache_disabled(self, cache, monkeypatch):
-        """FR-008: with the global switch off, invalidate must not touch the backend."""
-        monkeypatch.setattr(cart_settings, "MASTER_DATA_CACHE_ENABLED", False)
-        delete_calls = 0
+    async def test_invalidate_is_noop_when_cache_disabled(self):
+        """FR-008: with caching disabled (None backend), invalidate is a no-op."""
+        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=None)
+        await repo.invalidate("A")  # MUST NOT raise (no backend to touch)
 
-        async def counting_delete(_key):
-            nonlocal delete_calls
-            delete_calls += 1
-            return True
-        monkeypatch.setattr(cache, "delete", counting_delete)
-
-        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=cache)
-        await repo.invalidate("A")
-        assert delete_calls == 0
-
-    async def test_invalidate_all_is_noop_when_cache_disabled(self, cache, monkeypatch):
-        monkeypatch.setattr(cart_settings, "MASTER_DATA_CACHE_ENABLED", False)
-        increment_calls = 0
-
-        async def counting_increment(_key):
-            nonlocal increment_calls
-            increment_calls += 1
-            return 1
-        monkeypatch.setattr(cache, "increment", counting_increment)
-
-        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=cache)
-        await repo.invalidate_all()
-        assert increment_calls == 0
+    async def test_invalidate_all_is_noop_when_cache_disabled(self):
+        repo = FakeOneRepo(tenant_id="T1", store_code="S1", cache_backend=None)
+        await repo.invalidate_all()  # MUST NOT raise (no backend to touch)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes the master-data cache **base class** portable to other repos/services by removing its only app-specific import (`app.config.settings_cart`). After this, both the commons cache layer and `AbstractMasterDataRepository` are free of any app coupling and can be lifted into another repo as-is.

> **Stacked on #129** (base branch = `fix/cart-integration-master-cache-backend`). Merge #129 first; this PR's diff shows only the decoupling commit. The decouple relies on the integration-tier fix from #129 to keep integration tests green.

## What changed

- Model "caching disabled" as `cache_backend is None` instead of reading `cart_settings.MASTER_DATA_CACHE_ENABLED` inside the base class. The enable/disable decision now lives in `main.py`'s `lifespan`, which sets `app.state.master_cache_backend = None` when disabled.
- `cache.py` invalidation endpoint returns a no-op success when the backend is `None`.
- Unit tests express "disabled" via `cache_backend=None`.

## Portability outcome

- **Copy as-is** to another repo: `kugel_common/utils/cache/*` (commons cache layer) + `AbstractMasterDataRepository` (base class).
- **Re-implement per repo**: app-specific subclasses (`document_class` / `cache_namespace` / per-namespace TTL) and the wiring (lifespan, DI, `masterstore.yaml`, settings keys).

## Test plan

- [x] cart unit: 510 pass
- [x] full `run_all_tests.sh` on the live stack: unit 8/8, integration 7/7, e2e 8/8 suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)