### PR TITLE
feat(receipt): device-agnostic print-document JSON in receipt_text (was XML) + R/J/RJ channel (#139)

### DIFF
--- a/docs/en/commons/common-function-spec.md
+++ b/docs/en/commons/common-function-spec.md
@@ -436,16 +436,49 @@ class AbstractReceiptData(ABC):
 
 ```python
 class ReceiptData(BaseModel):
-    """Receipt data class (ReceiptData, not ReceiptDataModel)"""
-    
-    tenant_id: str
-    terminal_id: str
-    business_date: str
-    generate_date_time: str
-    tranlog_id: str
-    receipt_text: str
-    journal_text: str
+    """Result of a receipt strategy (holds the generated text only)."""
+
+    receipt_text: str   # device-agnostic print document, serialized as a JSON string
+    journal_text: str   # plain-text electronic journal
 ```
+
+**Note:** `receipt_text` carries the device-agnostic print document (the
+`print_document` schema) serialized with `json.dumps`. The field name and `str`
+type are unchanged; only the content format moved from XML to JSON (feature
+#139). `journal_text` remains plain text.
+
+### Print Document JSON Model (`print_document_model.py`)
+
+The structured receipt data uses an OPOS/printer-independent, semantic
+**JSON model** (the old `pydantic-xml` `PrintData`/`BaseXmlModel`/`Table` has
+been removed). `AbstractReceiptData.make_receipt_data()` builds this model and
+stores `json.dumps(...)` of it in `ReceiptData.receipt_text`.
+
+```python
+class PrintDocument(BaseModel):
+    """Root print document. to_dict() emits camelCase JSON."""
+    schema_version: str = "1.0"
+    metadata: Metadata           # documentType/tenantId/storeCode/terminalNo/
+                                 # transactionNo/receiptNo/businessDate/
+                                 # generatedAt/locale/charsPerLine
+    elements: list[Element]      # ordered print elements
+
+# Elements (discriminated by `type`), all inheriting PrintElement:
+#   text / columns(left/mid(startCol)/right) / ruledLine / feed / cut /
+#   barcode / qrcode / image / logo
+
+class PrintElement(BaseModel):
+    """Base for all elements. Carries the internal routing channel
+    (R/J/RJ, default RJ), excluded from the JSON output (exclude=True)."""
+    channel: Literal["R", "J", "RJ"] = Field("RJ", exclude=True)
+```
+
+**R/J/RJ channel (station)**: each element carries an internal `channel`;
+`make_receipt_data()` routes R/RJ elements into `receipt_text` and J/RJ into
+`journal_text`. The channel never appears in the JSON. The `line_split` /
+`line_center` / `line_left` / `line_right` / `line_boarder` helpers accept a
+`channel` argument (default `RJ`). See
+`specs/139-receipt-print-schema/contracts/print-document.schema.md`.
 
 ## 10. Additional Features
 

--- a/docs/ja/commons/common-function-spec.md
+++ b/docs/ja/commons/common-function-spec.md
@@ -472,30 +472,42 @@ class ReceiptData(BaseModel):
     journal_text: str = ""   # 電子ジャーナル用テキスト
 ```
 
-**注:** `ReceiptData`は生成されたテキストのみを保持するシンプルな構造です。トランザクション情報（tenant_id, terminal_id等）は、レシート生成時に`AbstractReceiptData`の実装クラスが処理します。
+**注:** `ReceiptData`は生成されたテキストのみを保持するシンプルな構造です。`receipt_text`は **device-agnostic な印字データ（`print_document`スキーマ）を `json.dumps` した JSON 文字列**を保持します（旧来の XML 文字列から移行）。フィールド名・型（`str`）は不変で、中身のフォーマットのみ XML→JSON に変わりました。`journal_text`は従来どおりプレーンテキストの電子ジャーナルです（feature #139）。
 
-### レシート生成用XMLモデル
+### 印字データJSONモデル (`print_document_model.py`)
 
-レシートの構造化データには以下のPydanticXMLモデルを使用：
+レシートの構造化データには、OPOS・特定プリンタ機種に依存しない意味要素ベースの **JSON モデル**を使用します（旧 `pydantic-xml` の `PrintData`/`BaseXmlModel`/`Table` は撤去）。`AbstractReceiptData.make_receipt_data()` がこのモデルを構築し、`json.dumps` した文字列を `ReceiptData.receipt_text` に格納します。
 
 ```python
-class PrintData(BaseXmlModel):
-    """印刷データのルート要素"""
-    pages: list[Page]
+class PrintDocument(BaseModel):
+    """印字文書のルート。to_dict() で camelCase JSON 化"""
+    schema_version: str = "1.0"
+    metadata: Metadata           # documentType/tenantId/storeCode/terminalNo/
+                                 # transactionNo/receiptNo/businessDate/
+                                 # generatedAt/locale/charsPerLine
+    elements: list[Element]      # 順序付き印字要素列
 
-class Page(BaseXmlModel):
-    """ページ要素（複数行やテーブルを含む）"""
-    lines: list[Line | Table]
+# 要素（type で判別するユニオン）: いずれも PrintElement を継承
+#   text       … 単一テキスト行（value/align/style）
+#   columns    … 複数カラム行（left/mid(startCol)/right・カラム単位 style）
+#   ruledLine  … 区切り罫線（char）
+#   feed       … 行送り（lines）
+#   cut        … レシートカット（full/partial）
+#   barcode    … バーコード（symbology/data/height/hri/align）
+#   qrcode     … QRコード（data/errorCorrection/moduleSize/align）
+#   image      … 画像（source: base64/url）
+#   logo       … 事前登録ロゴ（logoId）
 
-class Line(BaseXmlModel):
-    """単一行要素"""
-    text: str
-    align: str = "left"
+class Style(BaseModel):
+    """文字修飾: bold/underline/reverse/scaleWidth/scaleHeight(倍角 1-8)/font"""
 
-class Table(BaseXmlModel):
-    """テーブル要素"""
-    rows: list[TableRow]
+class PrintElement(BaseModel):
+    """全要素の基底。内部ルーティング属性 channel(R/J/RJ, 既定 RJ) を持つ。
+    channel は JSON 出力からは除外(exclude=True)される内部属性。"""
+    channel: Literal["R", "J", "RJ"] = Field("RJ", exclude=True)
 ```
+
+**R/J/RJ チャネル（ステーション）**: 各要素は内部 `channel` を持ち、`make_receipt_data()` が振り分けます。R/RJ → `receipt_text`（レシート）、J/RJ → `journal_text`（電子ジャーナル）。`channel` は JSON 出力には現れません。`line_split`/`line_center`/`line_left`/`line_right`/`line_boarder` の各ヘルパに `channel` 引数（既定 `RJ`）で指定できます。詳細は `specs/139-receipt-print-schema/contracts/print-document.schema.md`。
 
 ## 10. 追加の機能
 

--- a/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
+++ b/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
@@ -29,20 +29,12 @@ from kugel_common.receipt.print_document_model import (
     RuledLineElement,
     TextElement,
 )
-from kugel_common.receipt.receipt_data_model import Constants as const
 from kugel_common.receipt.receipt_data_model import Line, Page
 from kugel_common.utils.text_helper import TextHelper
 
 logger = getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
-
-# Map the internal alignment constants to the print_document align vocabulary.
-_ALIGN_TO_DOC = {
-    const.ALIGN_CENTER: "center",
-    const.ALIGN_LEFT: "left",
-    const.ALIGN_RIGHT: "right",
-}
 
 
 class ReceiptData(BaseModel):
@@ -127,7 +119,9 @@ class AbstractReceiptData(ABC, Generic[T]):
             elif el_type == "columns":
                 text += self._render_columns_element(element, width)
             elif el_type == "ruledLine":
-                text += "".center(width, element.char or "-")
+                # str.center requires a single fill char; take the first char.
+                fill_char = (element.char or "-")[:1] or "-"
+                text += "".center(width, fill_char)
             else:
                 # feed/cut/barcode/qrcode/image/logo do not appear in the
                 # current production strategies; skip them in the plain-text
@@ -168,7 +162,12 @@ class AbstractReceiptData(ABC, Generic[T]):
             if column.slot == "right":
                 right_value = column.value
                 continue
-            start = 0 if column.slot == "left" else (column.start_col or cursor)
+            if column.slot == "left":
+                start = 0
+            elif column.start_col is not None:
+                start = column.start_col
+            else:
+                start = cursor
             if start > cursor:
                 line += TextHelper.space(start - cursor)
                 cursor = start

--- a/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
+++ b/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
@@ -12,72 +12,191 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from pydantic import BaseModel
-from typing import Generic, TypeVar
-from xml.dom.minidom import parseString
-from logging import getLogger
 from datetime import datetime
+from logging import getLogger
+from typing import Any, Generic, Optional, TypeVar
+import json
 import locale
 
+import wcwidth
+from pydantic import BaseModel
+
+from kugel_common.receipt.print_document_model import (
+    Column,
+    ColumnsElement,
+    Metadata,
+    PrintDocument,
+    RuledLineElement,
+    TextElement,
+)
+from kugel_common.receipt.receipt_data_model import Constants as const
+from kugel_common.receipt.receipt_data_model import Line, Page
+from kugel_common.utils.text_helper import TextHelper
 
 logger = getLogger(__name__)
 
-from kugel_common.receipt.receipt_data_model import Page, Line, PrintData, Constants as const
-from kugel_common.utils.text_helper import TextHelper
+T = TypeVar("T", bound=BaseModel)
 
-T = TypeVar('T', bound=BaseModel)
+# Map the internal alignment constants to the print_document align vocabulary.
+_ALIGN_TO_DOC = {
+    const.ALIGN_CENTER: "center",
+    const.ALIGN_LEFT: "left",
+    const.ALIGN_RIGHT: "right",
+}
+
 
 class ReceiptData(BaseModel):
+    """Result of a receipt strategy: ``receipt_text`` holds the device-agnostic
+    print document serialized as a JSON string; ``journal_text`` is the
+    plain-text electronic journal."""
+
     receipt_text: str
     journal_text: str
+
 
 class AbstractReceiptData(ABC, Generic[T]):
 
     def __init__(self, name: str, width: int = 32) -> None:
         self.name = name
         self.width = width
+        # Subclasses may override to emit a different documentType (e.g. "report").
+        self.document_type = "receipt"
 
     def make_receipt_data(self, model: T) -> ReceiptData:
-        print_data = self.generate_print_data(model)
-        receipt_text = self.make_receipt_text(print_data)
-        journal_text = self.make_journal_text(print_data)
+        page = self.generate_print_data(model)
+        # The print document (a structured dict) is serialized to a JSON string
+        # and carried in the ``receipt_text`` field (same field/type as before;
+        # only the content changed from XML to JSON).
+        print_document = self.build_print_document(model, page.lines)
+        receipt_text = json.dumps(print_document, ensure_ascii=False)
+        journal_text = self.render_journal_text(page.lines)
         return ReceiptData(receipt_text=receipt_text, journal_text=journal_text)
-    
-    def generate_print_data(self, model: T) -> PrintData:
-        page  = Page()
+
+    def generate_print_data(self, model: T) -> Page:
+        page = Page()
         self.make_receipt_header(model, page)
         self.make_receipt_body(model, page)
         self.make_receipt_footer(model, page)
-        print_data = PrintData(pages=[page])
-        return print_data
+        return page
 
-    def make_receipt_text(self, print_data: PrintData) -> str:
-        print_str = parseString(print_data.to_xml())
-        print_xml_str = print_str.toprettyxml(indent="\t")
-        print_xml_str = print_xml_str.encode('utf-8').decode('utf-8')
-        logger.debug(f"receipt_text: {print_xml_str}")
-        return print_xml_str
+    #
+    # print_document (JSON) generation
+    #
+    def build_print_document(self, model: T, elements: list[Line]) -> dict[str, Any]:
+        """Build the device-agnostic print document (camelCase dict) from the
+        ordered print elements produced by the strategy.
 
+        Only elements routed to the receipt (channel R or RJ) are included; the
+        channel attribute itself is excluded from the serialized output."""
+        metadata = self._build_metadata(model)
+        receipt_elements = [e for e in elements if getattr(e, "channel", "RJ") in ("R", "RJ")]
+        document = PrintDocument(metadata=metadata, elements=receipt_elements)
+        doc_dict = document.to_dict()
+        logger.debug(f"print_document: {doc_dict}")
+        return doc_dict
+
+    def _build_metadata(self, model: T) -> Metadata:
+        """Extract document metadata from the source model via common attributes."""
+        generated_at = getattr(model, "generate_date_time", None)
+        return Metadata(
+            document_type=self.document_type,
+            tenant_id=getattr(model, "tenant_id", None),
+            store_code=getattr(model, "store_code", None),
+            terminal_no=getattr(model, "terminal_no", None),
+            transaction_no=getattr(model, "transaction_no", None),
+            receipt_no=getattr(model, "receipt_no", None),
+            business_date=getattr(model, "business_date", None),
+            generated_at=generated_at,
+            chars_per_line=self.width,
+        )
+
+    #
+    # journal_text (plain text) generation — kept byte-equivalent to the
+    # previous PrintData.to_text() implementation.
+    #
+    def render_journal_text(self, elements: list[Line]) -> str:
+        width = int(self.width)
+        text = ""
+        for element in elements:
+            # Only elements routed to the journal (channel J or RJ) are rendered.
+            if getattr(element, "channel", "RJ") not in ("J", "RJ"):
+                continue
+            el_type = getattr(element, "type", None)
+            if el_type == "text":
+                text += self._render_text_element(element, width)
+            elif el_type == "columns":
+                text += self._render_columns_element(element, width)
+            elif el_type == "ruledLine":
+                text += "".center(width, element.char or "-")
+            else:
+                # feed/cut/barcode/qrcode/image/logo do not appear in the
+                # current production strategies; skip them in the plain-text
+                # journal (they carry no plain-text representation here).
+                continue
+            text += "\n"
+        return text
+
+    def _render_text_element(self, element: TextElement, width: int) -> str:
+        value = element.value if element.value is not None else ""
+        match element.align:
+            case "center":
+                return TextHelper.fixed_center(value, width)
+            case "right":
+                return TextHelper.fixed_right(value, width)
+            case _:
+                return TextHelper.fixed_left(value, width)
+
+    def _render_columns_element(self, element: ColumnsElement, width: int) -> str:
+        columns = element.columns
+        slots = {c.slot for c in columns}
+        # Production strategies always emit a left+right pair (from line_split);
+        # reproduce the exact previous split formatting to avoid any regression.
+        if len(columns) == 2 and slots == {"left", "right"}:
+            left = next(c for c in columns if c.slot == "left").value
+            right = next(c for c in columns if c.slot == "right").value
+            left_max_width = max(0, width - wcwidth.wcswidth(right) - 1)
+            return TextHelper.fixed_left(left, left_max_width, truncate=True) + " " + right
+        # General layout (used by richer documents): place left/mid by position
+        # and right-justify the right slot.
+        return self._render_columns_general(columns, width)
+
+    def _render_columns_general(self, columns: list[Column], width: int) -> str:
+        line = ""
+        cursor = 0
+        right_value: Optional[str] = None
+        for column in columns:
+            if column.slot == "right":
+                right_value = column.value
+                continue
+            start = 0 if column.slot == "left" else (column.start_col or cursor)
+            if start > cursor:
+                line += TextHelper.space(start - cursor)
+                cursor = start
+            line += column.value
+            cursor += wcwidth.wcswidth(column.value)
+        if right_value is not None:
+            pad = width - cursor - wcwidth.wcswidth(right_value)
+            line += TextHelper.space(max(1, pad)) + right_value
+        return line
+
+    #
+    # date/format helpers
+    #
     def format_datetime(self, date_time_str: str) -> str:
-        locale.setlocale(locale.LC_ALL, 'ja_JP.UTF-8')
+        locale.setlocale(locale.LC_ALL, "ja_JP.UTF-8")
         dt = datetime.fromisoformat(date_time_str)
         dt_formatted = dt.strftime("%Y年%m月%d日(%a) %H:%M")
         return dt_formatted
-    
+
     def format_business_date(self, business_date_str: str) -> str:
-        locale.setlocale(locale.LC_ALL, 'ja_JP.UTF-8')
+        locale.setlocale(locale.LC_ALL, "ja_JP.UTF-8")
         if len(business_date_str) == 8 and business_date_str.isdigit():
             business_date_str = business_date_str[:4] + "-" + business_date_str[4:6] + "-" + business_date_str[6:8]
             dt = datetime.fromisoformat(business_date_str)
             dt_formatted = dt.strftime("%Y年%m月%d日(%a)")
         else:
-            dt_formatted = business_date_str # no format
+            dt_formatted = business_date_str  # no format
         return dt_formatted
-
-    def make_journal_text(self, print_data: PrintData) -> str:
-        journal_text = print_data.to_text(width=self.width)
-        logger.debug(f"journal_text: {journal_text}")
-        return journal_text
 
     @abstractmethod
     def make_receipt_header(self, model: T, page: Page):
@@ -92,30 +211,42 @@ class AbstractReceiptData(ABC, Generic[T]):
         pass
 
     #
-    # make line data for receipt
+    # line builders (backward-compatible shims) — produce print_document
+    # elements instead of XML lines. Signatures and call sites are unchanged.
     #
-    def line_split(self, item1: str, item2: str) -> Line:
-        return Line(type=const.TYPE_TEXT, align=const.ALIGN_SPLIT, item1=item1, item2=item2)
-    
-    def line_center(self, text: str) -> Line:
-        return Line(type=const.TYPE_TEXT, align=const.ALIGN_CENTER, description=text, item1=None, item2=None)
+    # ``channel`` routes the line to the receipt (R), the journal (J), or both
+    # (RJ, default). It defaults to RJ so existing call sites are unchanged.
+    def line_split(self, item1: str, item2: str, channel: str = "RJ") -> Line:
+        return ColumnsElement(
+            channel=channel,
+            columns=[
+                Column(slot="left", value=item1),
+                Column(slot="right", value=item2),
+            ],
+        )
 
-    def line_left(self, text: str) -> Line:
-        return Line(type=const.TYPE_TEXT, align=const.ALIGN_LEFT, description=text, item1=None, item2=None)
-    
-    def line_right(self, text: str) -> Line:
-        return Line(type=const.TYPE_TEXT, align=const.ALIGN_RIGHT, description=text, item1=None, item2=None)
-    
-    def line_boarder(self) -> Line:
-        return Line(type=const.TYPE_LINE, align=None, description=None, item1=None, item2=None)
+    def line_center(self, text: str, channel: str = "RJ") -> Line:
+        return TextElement(channel=channel, value=text, align="center")
 
+    def line_left(self, text: str, channel: str = "RJ") -> Line:
+        return TextElement(channel=channel, value=text, align="left")
+
+    def line_right(self, text: str, channel: str = "RJ") -> Line:
+        return TextElement(channel=channel, value=text, align="right")
+
+    def line_boarder(self, channel: str = "RJ") -> Line:
+        return RuledLineElement(channel=channel, char="-")
+
+    #
+    # text helpers
+    #
     def space(self, width: int) -> str:
         return TextHelper.space(width)
 
     def comma(self, value: float) -> str:
-        return TextHelper.comma(value) 
+        return TextHelper.comma(value)
 
-    def yen(self, value: float, mark: str = '\\') -> str:
+    def yen(self, value: float, mark: str = "\\") -> str:
         return TextHelper.yen(value, mark)
 
     def zero_fill(self, value: int, width: int) -> str:

--- a/services/commons/src/kugel_common/receipt/print_document_model.py
+++ b/services/commons/src/kugel_common/receipt/print_document_model.py
@@ -1,0 +1,214 @@
+# Copyright 2025 masa@kugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Device-agnostic print-data JSON model (`print_document`).
+
+This module defines the OPOS/printer-independent print-data schema produced by
+the backend (cart/terminal/report) and consumed downstream (frontend/device)
+for receipt rendering. See specs/139-receipt-print-schema/contracts.
+
+Key points:
+  - Output is camelCase JSON via ``model_dump(by_alias=True, exclude_none=True)``.
+  - Multi-column lines (`columns`) are emitted as *semantic* columns (no baked
+    spaces); column alignment / spacing is the consumer's responsibility based
+    on ``metadata.charsPerLine``.
+  - Styling (`style`) applies at line level for `text` and at column level for
+    `columns` entries.
+"""
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# camelCase aliasing; allow construction by either python or alias name.
+_camel = ConfigDict(populate_by_name=True)
+
+
+class Style(BaseModel):
+    """Character styling. Unset fields fall back to renderer/consumer defaults."""
+
+    model_config = _camel
+    bold: Optional[bool] = None
+    underline: Optional[int] = Field(None, ge=0, le=2)
+    reverse: Optional[bool] = None
+    scale_width: Optional[int] = Field(None, ge=1, le=8, alias="scaleWidth")
+    scale_height: Optional[int] = Field(None, ge=1, le=8, alias="scaleHeight")
+    font: Optional[Literal["A", "B"]] = None
+
+
+class PrintElement(BaseModel):
+    """Base for all print elements.
+
+    Carries the internal routing channel (R=receipt only, J=journal only,
+    RJ=both). The backend uses it to split content between ``print_document``
+    (R/RJ) and ``journal_text`` (J/RJ). It is an internal routing attribute and
+    is excluded from the serialized print document (the consumer receives the
+    receipt view only, with no per-element station)."""
+
+    model_config = _camel
+    channel: Literal["R", "J", "RJ"] = Field("RJ", exclude=True)
+
+
+class TextElement(PrintElement):
+    """A single-content text line (styling applies at line level)."""
+
+    model_config = _camel
+    type: Literal["text"] = "text"
+    value: str
+    align: Literal["left", "center", "right"] = "left"
+    style: Optional[Style] = None
+
+
+class Column(BaseModel):
+    """One column within a `columns` line (styling applies at column level)."""
+
+    model_config = _camel
+    slot: Literal["left", "mid", "right"]
+    value: str
+    # Required only for the `mid` slot: fixed offset from the left (half-width
+    # columns, 0-based, based on metadata.charsPerLine).
+    start_col: Optional[int] = Field(None, alias="startCol")
+    # Default per slot: left/mid -> left, right -> right (resolved by consumer).
+    align: Optional[Literal["left", "center", "right"]] = None
+    style: Optional[Style] = None
+
+
+class ColumnsElement(PrintElement):
+    """A multi-column line emitted as semantic columns (no baked spaces)."""
+
+    type: Literal["columns"] = "columns"
+    columns: list[Column]
+
+
+class RuledLineElement(PrintElement):
+    """A horizontal separator drawn across the full printer width."""
+
+    type: Literal["ruledLine"] = "ruledLine"
+    char: str = "-"
+
+
+class FeedElement(PrintElement):
+    """Vertical line feed."""
+
+    type: Literal["feed"] = "feed"
+    lines: int = Field(ge=1, le=255)
+
+
+class CutElement(PrintElement):
+    """Paper cut."""
+
+    type: Literal["cut"] = "cut"
+    mode: Literal["full", "partial"] = "full"
+
+
+class BarcodeElement(PrintElement):
+    """Barcode element (symbology is a logical name resolved by the consumer)."""
+
+    model_config = _camel
+    type: Literal["barcode"] = "barcode"
+    symbology: str
+    data: str
+    height: Optional[int] = None
+    module_width: Optional[int] = Field(None, alias="moduleWidth")
+    hri: Literal["none", "above", "below"] = "none"
+    align: Literal["left", "center", "right"] = "center"
+
+
+class QrcodeElement(PrintElement):
+    """QR code element."""
+
+    model_config = _camel
+    type: Literal["qrcode"] = "qrcode"
+    data: str
+    error_correction: Literal["L", "M", "Q", "H"] = Field("M", alias="errorCorrection")
+    module_size: Optional[int] = Field(None, alias="moduleSize")
+    align: Literal["left", "center", "right"] = "center"
+
+
+class ImageSource(BaseModel):
+    """Image source: base64-embedded data or a URL reference."""
+
+    model_config = _camel
+    kind: Literal["base64", "url"]
+    data: str
+    format: Optional[str] = None
+
+
+class ImageElement(PrintElement):
+    """Ad-hoc bitmap image element."""
+
+    model_config = _camel
+    type: Literal["image"] = "image"
+    source: ImageSource
+    align: Literal["left", "center", "right"] = "center"
+    # Width in dots, or "auto" for native size.
+    width: Union[int, Literal["auto"]] = "auto"
+
+
+class LogoElement(PrintElement):
+    """Pre-registered logo element (referenced by identifier)."""
+
+    model_config = _camel
+    type: Literal["logo"] = "logo"
+    logo_id: str = Field(alias="logoId")
+    align: Literal["left", "center", "right"] = "center"
+
+
+# Discriminated union of all print elements, ordered as they appear on output.
+Element = Annotated[
+    Union[
+        TextElement,
+        ColumnsElement,
+        RuledLineElement,
+        FeedElement,
+        CutElement,
+        BarcodeElement,
+        QrcodeElement,
+        ImageElement,
+        LogoElement,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class Metadata(BaseModel):
+    """Document metadata. ``charsPerLine`` is the design-reference width that the
+    consumer uses as the basis to adapt to the actual printer width."""
+
+    model_config = _camel
+    document_type: str = Field("receipt", alias="documentType")
+    tenant_id: Optional[str] = Field(None, alias="tenantId")
+    store_code: Optional[str] = Field(None, alias="storeCode")
+    terminal_no: Optional[int] = Field(None, alias="terminalNo")
+    transaction_no: Optional[int] = Field(None, alias="transactionNo")
+    receipt_no: Optional[int] = Field(None, alias="receiptNo")
+    business_date: Optional[str] = Field(None, alias="businessDate")
+    generated_at: Optional[str] = Field(None, alias="generatedAt")
+    locale: str = "ja-JP"
+    chars_per_line: int = Field(32, alias="charsPerLine")
+
+
+class PrintDocument(BaseModel):
+    """Root print-data document. Serialize with :meth:`to_dict` for storage and
+    transport (camelCase, omitting unset fields)."""
+
+    model_config = _camel
+    schema_version: str = Field("1.0", alias="schemaVersion")
+    metadata: Metadata
+    elements: list[Element] = Field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a camelCase dict suitable for MongoDB / pub-sub / API."""
+        return self.model_dump(by_alias=True, exclude_none=True)

--- a/services/commons/src/kugel_common/receipt/receipt_data_model.py
+++ b/services/commons/src/kugel_common/receipt/receipt_data_model.py
@@ -11,156 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pydantic_xml import BaseXmlModel, attr, element
-from typing import List, Optional
-from logging import getLogger
-import wcwidth
-from pydantic import Field
-from xml.sax.saxutils import escape
+"""
+Internal intermediate representation used while a receipt strategy builds its
+content. A strategy appends print elements to ``Page.lines`` via the
+``line_*`` helpers on ``AbstractReceiptData``; the base then renders the page
+into the device-agnostic ``print_document`` (JSON) and the plain-text
+``journal_text``.
 
-from kugel_common.utils.text_helper import TextHelper
+The XML representation (previously ``PrintData`` / pydantic-xml) has been
+removed; the canonical print-data format is now JSON (see
+``print_document_model``).
+"""
+from logging import getLogger
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from kugel_common.receipt.print_document_model import Element
 
 logger = getLogger(__name__)
 
-# constants
+
 class Constants:
-    """
-    Constants class
-    
-    Defines constants used for receipt printing, including text display types,
-    alignment options, border settings, and frame types.
-    """
+    """Constants used while building receipt content (alignment, element kinds)."""
+
     TYPE_TEXT = "Text"
     TYPE_LINE = "Line"
-    TYPE_BYTE = "Byte"
 
     ALIGN_CENTER = "Center"
     ALIGN_LEFT = "Left"
     ALIGN_RIGHT = "Right"
     ALIGN_SPLIT = "Split"
 
-    BORADER_OFF = "0"
-    BORADER_ON = "1"
 
-    FRAME_BOARDER = "boarder"
-    FRAME_HSIDES = "hsides"
+# Backward-compatible alias: strategies type-annotate built elements as ``Line``.
+# Elements are now ``print_document`` elements (TextElement/ColumnsElement/...).
+Line = Element
 
-    DIMENSION_QR_CODE = "QR_CODE"
 
-# Line model
-class Line(BaseXmlModel, tag="Line"):
-    """
-    Line element model
+class Page(BaseModel):
+    """A page accumulates ordered print elements appended by a strategy."""
 
-    Represents a single line on a receipt.
-    Defines the type, alignment, and content of text lines.
-    """
-    type: str = attr()
-    align: Optional[str] = attr(default=None)
-    dimension: Optional[str] = attr(default=None)
-    description: Optional[str] = Field(default=None)
-    item1: Optional[str] = element(tag="Item1", default=None)
-    item2: Optional[str] = element(tag="Item2", default=None)
-
-    def to_xml(self, **kwargs):
-        """Custom XML serialization"""
-        # Build the XML string manually when description is present
-        if self.description is not None:
-            attrs = [f'type="{escape(self.type)}"']
-            if self.align:
-                attrs.append(f'align="{escape(self.align)}"')
-            if self.dimension:
-                attrs.append(f'dimension="{escape(self.dimension)}"')
-            attr_string = ' '.join(attrs)
-            # Escape the description content
-            return f'<Line {attr_string}>{escape(self.description)}</Line>'.encode('utf-8')
-        else:
-            # Use default serialization for other cases
-            kwargs['exclude_none'] = True
-            return super().to_xml(**kwargs)
-
-    def model_post_init(self, __context):
-        """Adjust item1 width after model initialization"""
-        # Store original item1 value
-        item1_original = self.item1
-        item2 = self.item2
-
-        # Adjust item1 if both item1 and item2 are present
-        if item1_original is not None and item2 is not None:
-            max_width = 32
-            item2_width = wcwidth.wcswidth(item2)
-            item1_max_width = max(0, max_width - item2_width - 1)
-            self.item1 = TextHelper.fixed_left(item1_original, item1_max_width, truncate=True)
-
-# TableRow model
-class TableRow(BaseXmlModel, tag="tr"):
-    """
-    Table row model
-    
-    Represents a single row in a table.
-    Contains multiple columns.
-    """
-    columns: List[str] = element(tag="td", default=[])
-
-# Table model
-class Table(BaseXmlModel, tag="Table"):
-    """
-    Table model
-    
-    Represents a table on a receipt.
-    Contains border, frame, alignment specifications, and multiple rows.
-    """
-    border: str = attr()
-    frame: str = attr()
-    align: Optional[str] = attr(default=None)
-    rows: List[TableRow] = element(default=[])
-
-# Page model
-class Page(BaseXmlModel, tag="Page"):
-    """
-    Page model
-    
-    Represents a single page of a receipt.
-    Contains multiple lines and tables.
-    """
-    lines: List[Line] = element(default=[])
-    tables: List[Table] = element(default=[])
-
-# PrintData model 
-class PrintData(BaseXmlModel, tag="PrintData"):
-    """
-    Print data model
-    
-    Root model representing the complete print data for a receipt.
-    Contains multiple pages and can be converted to XML format.
-    """
-    pages: List[Page] = element(default=[])
-
-    def to_text(self, width: int = 32) -> str:
-        text = ""
-        for page in self.pages:
-            for line in page.lines:
-                if line.type == Constants.TYPE_TEXT:
-                    if line.align is None:
-                        logger.warning(f"Align is None. line->{line}")
-                        continue
-                    desc = line.description if line.description is not None else ""
-                    item1 = line.item1 if line.item1 is not None else ""
-                    item2 = line.item2 if line.item2 is not None else ""
-                    match line.align:
-                        case Constants.ALIGN_CENTER:
-                            text += TextHelper.fixed_center(desc, int(width))
-                        case Constants.ALIGN_LEFT:
-                            text += TextHelper.fixed_left(desc, int(width))
-                        case Constants.ALIGN_RIGHT:
-                            text += TextHelper.fixed_right(desc, int(width))
-                        case Constants.ALIGN_SPLIT:
-                            # item1は既に調整済みなので、スペースを追加
-                            text += item1 + " " + item2
-                elif line.type == Constants.TYPE_LINE:
-                    text += "".center(int(width), "-")
-                elif line.type == Constants.TYPE_BYTE:
-                    logger.debug(f"Byte: {line}")
-                    raise ValueError("Not supported type: Byte")
-                text += "\n"
-        return text
+    lines: List[Element] = Field(default_factory=list)

--- a/services/commons/tests/unit/test_receipt_routing.py
+++ b/services/commons/tests/unit/test_receipt_routing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for R/J/RJ channel routing in AbstractReceiptData."""
+import json
+
 import pytest
 
 from kugel_common.receipt.abstract_receipt_data import AbstractReceiptData
@@ -29,6 +31,16 @@ class _Strategy(AbstractReceiptData):
 
     def make_receipt_footer(self, model, page: Page):
         pass
+
+
+class _ContentStrategy(_Strategy):
+    """Strategy that emits a small receipt body for end-to-end output tests."""
+
+    def make_receipt_body(self, model, page: Page):
+        page.lines.append(self.line_center("HEADER"))
+        page.lines.append(self.line_split("合計", "\\278"))
+        page.lines.append(self.line_boarder())
+        page.lines.append(self.line_left("JAN:4900000000000", channel="J"))
 
 
 class _Model:
@@ -87,3 +99,22 @@ def test_all_journal_only_yields_empty_receipt_view(strategy):
     elements = [strategy.line_left("only-journal", channel="J")]
     doc = strategy.build_print_document(_Model(), elements)
     assert doc["elements"] == []
+
+
+def test_make_receipt_data_receipt_text_is_json_print_document():
+    """receipt_text is a JSON string holding the print document (not XML);
+    journal_text is plain text. Locks the field contract locally."""
+    result = _ContentStrategy("default", 32).make_receipt_data(_Model())
+
+    # receipt_text parses as JSON and conforms to the print-document shape.
+    doc = json.loads(result.receipt_text)
+    assert doc["schemaVersion"] == "1.0"
+    assert doc["metadata"]["documentType"] == "receipt"
+    assert isinstance(doc["elements"], list) and len(doc["elements"]) >= 1
+    # The J-only line is excluded from the receipt view.
+    assert all("JAN:4900000000000" not in (e.get("value") or "") for e in doc["elements"])
+
+    # journal_text is plain text (not JSON) and includes the J-only line.
+    assert not result.journal_text.lstrip().startswith("{")
+    assert "JAN:4900000000000" in result.journal_text
+    assert "HEADER" in result.journal_text

--- a/services/commons/tests/unit/test_receipt_routing.py
+++ b/services/commons/tests/unit/test_receipt_routing.py
@@ -1,0 +1,89 @@
+# Copyright 2025 masa@kugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for R/J/RJ channel routing in AbstractReceiptData."""
+import pytest
+
+from kugel_common.receipt.abstract_receipt_data import AbstractReceiptData
+from kugel_common.receipt.receipt_data_model import Page
+
+
+class _Strategy(AbstractReceiptData):
+    """Concrete strategy with no-op section builders for direct routing tests."""
+
+    def make_receipt_header(self, model, page: Page):
+        pass
+
+    def make_receipt_body(self, model, page: Page):
+        pass
+
+    def make_receipt_footer(self, model, page: Page):
+        pass
+
+
+class _Model:
+    tenant_id = "t1"
+    store_code = "s1"
+    terminal_no = 1
+
+
+@pytest.fixture
+def strategy():
+    return _Strategy("default", 32)
+
+
+def _values(elements):
+    return [e.get("value") for e in elements if e.get("type") == "text"]
+
+
+def test_default_channel_is_rj_both(strategy):
+    """An element with no explicit channel goes to both receipt and journal."""
+    elements = [strategy.line_left("HELLO")]
+    doc = strategy.build_print_document(_Model(), elements)
+    journal = strategy.render_journal_text(elements)
+    assert "HELLO" in _values(doc["elements"])
+    assert "HELLO" in journal
+
+
+def test_receipt_only_channel_excluded_from_journal(strategy):
+    elements = [strategy.line_left("RECEIPT", channel="R")]
+    doc = strategy.build_print_document(_Model(), elements)
+    journal = strategy.render_journal_text(elements)
+    assert "RECEIPT" in _values(doc["elements"])
+    assert "RECEIPT" not in journal
+
+
+def test_journal_only_channel_excluded_from_receipt(strategy):
+    elements = [strategy.line_left("JAN:4900000000000", channel="J")]
+    doc = strategy.build_print_document(_Model(), elements)
+    journal = strategy.render_journal_text(elements)
+    assert "JAN:4900000000000" not in _values(doc["elements"])
+    assert "JAN:4900000000000" in journal
+
+
+def test_channel_not_serialized_into_print_document(strategy):
+    """The routing channel is internal and must never appear in the JSON output."""
+    elements = [
+        strategy.line_center("T", channel="R"),
+        strategy.line_split("a", "b", channel="RJ"),
+        strategy.line_boarder(channel="R"),
+    ]
+    doc = strategy.build_print_document(_Model(), elements)
+    for element in doc["elements"]:
+        assert "channel" not in element
+
+
+def test_all_journal_only_yields_empty_receipt_view(strategy):
+    elements = [strategy.line_left("only-journal", channel="J")]
+    doc = strategy.build_print_document(_Model(), elements)
+    assert doc["elements"] == []

--- a/specs/139-receipt-print-schema/checklists/requirements.md
+++ b/specs/139-receipt-print-schema/checklists/requirements.md
@@ -1,0 +1,35 @@
+# 仕様書品質チェックリスト: device-agnostic な印字データスキーマ（XML 撤去・JSON 化）
+
+**目的**: 計画フェーズに進む前に仕様書の完全性と品質を検証する
+**作成日**: 2026-06-07
+**タイプ**: 機能要求
+**フィーチャー**: [spec.md](../spec.md)（#139）
+
+## 内容の品質
+
+- [x] 実装の詳細（言語・フレームワーク）が spec に混入していない（pydantic 表現は contracts に分離）
+- [x] ユーザー価値とビジネスニーズに焦点を当てている
+- [x] すべての必須セクションが完成している
+
+## 要件の完全性
+
+- [x] `[要確認]` マーカーが残っていない（Clarifications で確定）
+- [x] 要件がテスト可能で明確である（各 FR に受け入れ基準）
+- [x] 成功基準が測定可能である（SC-001〜006）
+- [x] すべての受け入れシナリオが定義されている（US1〜US4）
+- [x] エッジケースが特定されている
+- [x] スコープが明確に定義されている（Out of Scope で device-gateway/能力照会/冪等性を除外）
+- [x] 依存関係が特定されている（stpos #316 流用元、Issue #139）
+
+## kugelpos 固有の確定事項（stpos #316 からの再スコープ）
+
+- [x] **DeviceGW API 契約・frontend パススルー契約はスコープ外**（消費者責務として短く参照）
+- [x] **terminal の開閉店/現金レシートも JSON 化対象**（kugel_common XML 廃止に伴い必須）
+- [x] **report の帳票レシート生成器（4 種）も JSON 化対象**（`AbstractReceiptData` 経由のため連動）
+- [x] **R/J/RJ チャネルは kugelpos に存在しない** → FR-007 はチャネル軸を導入せず `journal_text` 維持に限定
+- [x] **spec 番号 = issue 番号（139）** に統一（流用元 stpos の方式に合わせる）
+
+## 備考
+
+- 影響範囲: kugel_common + cart + terminal + journal + report。`receipt_text` 参照は 146 箇所（document/schema/transformer/pub-sub/テスト）。
+- 印字生成器は計 7（cart×1, terminal×2, report×4）。基底 `AbstractReceiptData` の XML 撤去により全生成器が連動。

--- a/specs/139-receipt-print-schema/contracts/print-document.schema.md
+++ b/specs/139-receipt-print-schema/contracts/print-document.schema.md
@@ -1,0 +1,172 @@
+# 印字データ JSON スキーマ定義（`print_document`）
+
+- **ステータス**: ドラフト（#139）
+- **対象**: backend（kugel_common 経由で cart/terminal/report）が生成し、消費者（frontend/device）が描画/転送する印字データ
+- **関連**: [spec.md](../spec.md)（#139）、流用元 stpos-backend #316 contracts
+- **出力形式**: camelCase JSON（消費者向け契約）。pydantic は `model_dump(by_alias=True, exclude_none=True)` で出力
+
+> **前提**:
+> - 複数カラム行は `columns` 要素で表し、**各カラムが独立した `value`・`style`・位置**を持つ（カラム単位の倍角/強調が可能）。
+> - カラム位置は backend が **`metadata.charsPerLine`（設計基準桁数）** を基準に設計する。`mid` は左からの固定オフセット `startCol`、`right` は右端終端。
+> - **桁揃え（空白計算・配置）と実機描画は消費者の責務**。backend は意味カラムを出力し空白を焼き込まない。
+> - `style`（倍角・強調等）は **`text` は行単位 / `columns` はカラム単位**で適用。
+> - R/J/RJ チャネル（ステーション）は backend の**内部ルーティング属性**であり、各要素を `print_document`（R/RJ）と `journal_text`（J/RJ）へ振り分ける。**この属性は本スキーマ（JSON 出力）には現れない** — `print_document` は R/RJ のレシートビューのみを表す（下記「ルーティングチャネル」参照）。
+
+---
+
+## ドキュメント構造
+
+```jsonc
+{
+  "schemaVersion": "1.0",
+  "metadata": { /* 下記 */ },
+  "elements": [ /* 順序付き印字要素列 */ ]
+}
+```
+
+### metadata
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `documentType` | string | ○ | `"receipt"`（帳票は `"report"` を想定） |
+| `tenantId` | string | ○ | テナント識別子 |
+| `storeCode` | string | ○ | 店舗コード |
+| `terminalNo` | int | ○ | 端末番号 |
+| `transactionNo` | int | △ | 取引番号 |
+| `receiptNo` | int | △ | レシート番号 |
+| `businessDate` | string(`YYYY-MM-DD`) | △ | 営業日 |
+| `generatedAt` | string(ISO8601) | ○ | 生成時刻（タイムゾーン付き） |
+| `locale` | string | △ | 例 `"ja-JP"` |
+| `charsPerLine` | int | ○ | **設計基準桁数（半角換算）**。`columns` の `startCol`・右端終端・`text` 整列はこの桁数を基準に設計する。消費者はこの値を基準に実機幅へ適合させる |
+
+---
+
+## elements（`type` で判別する要素ユニオン）
+
+### `text` — 単一内容のテキスト1行
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"text"` | — | |
+| `value` | string | — | 印字文字列（1行） |
+| `align` | `left`\|`center`\|`right` | `left` | 行全体の寄せ（`charsPerLine` 基準） |
+| `style` | Style | （なし） | **行単位**の文字修飾 |
+
+### `columns` — 複数カラム行
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"columns"` | — | |
+| `columns` | Column[] | — | カラムの配列。任意組み合わせ（`left`+`right` だけ／`left`+`mid`+`right` 等） |
+
+#### Column
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `slot` | `left`\|`mid`\|`right` | — | `left`=左端起点 / `mid`=`startCol` 起点 / `right`=右端終端 |
+| `value` | string | — | カラムの文字列 |
+| `startCol` | int | — | **`mid` のみ必須**。左からの固定オフセット（半角換算・0始まり、`charsPerLine` 基準） |
+| `align` | `left`\|`center`\|`right` | `left`（`right` slot は `right`） | カラム内の寄せ |
+| `style` | Style | （なし） | **カラム単位**の文字修飾 |
+
+**レイアウト規則（消費者が実施）**
+- `left` は col 0 から、`mid` は `startCol` から右へ、`right` は右端へ寄せる。
+- 桁衝突時は `mid` の開始位置で `left` を切詰める（同様に `right` の開始位置で `mid` を切詰める）。
+- 倍角カラムは 2 セル換算で配置する。
+- `charsPerLine`（設計基準）と実機幅が異なる場合、消費者が `charsPerLine` を基準に実幅へ適合させる。
+
+### `ruledLine` — 区切り罫線
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"ruledLine"` | — | |
+| `char` | string | `"-"` | 罫線文字。幅いっぱいに敷く |
+
+### `feed` — 行送り
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"feed"` | — | |
+| `lines` | int | — | 送る行数（1–255） |
+
+### `cut` — レシートカット
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"cut"` | — | |
+| `mode` | `full`\|`partial` | `full` | 全カット / 部分カット |
+
+### `barcode` — バーコード
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"barcode"` | — | |
+| `symbology` | string | — | `jan13`/`ean13`/`jan8`/`code39`/`code93`/`code128`/`itf`/`codabar`/`gs1-128` 等（論理名） |
+| `data` | string | — | バーコードデータ |
+| `height` | int | 機種既定 | バーコード高さ（dot） |
+| `moduleWidth` | int | 機種既定 | モジュール幅 |
+| `hri` | `none`\|`above`\|`below` | `none` | 人間可読文字（HRI）の位置 |
+| `align` | `left`\|`center`\|`right` | `center` | 配置 |
+
+### `qrcode` — QRコード
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"qrcode"` | — | |
+| `data` | string | — | QRデータ |
+| `errorCorrection` | `L`\|`M`\|`Q`\|`H` | `M` | 誤り訂正レベル |
+| `moduleSize` | int | 機種既定 | モジュールサイズ |
+| `align` | `left`\|`center`\|`right` | `center` | 配置 |
+
+### `image` — 画像
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"image"` | — | |
+| `source` | `{ kind: "base64"\|"url", data: string, format?: string }` | — | 画像ソース（base64 埋め込み or URL） |
+| `align` | `left`\|`center`\|`right` | `center` | 配置 |
+| `width` | int \| `"auto"` | `"auto"` | 幅（dot）。`auto`=原寸 |
+
+### `logo` — 事前登録ロゴ
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `type` | `"logo"` | — | |
+| `logoId` | string | — | 消費者/プリンタに事前登録したロゴ識別子 |
+| `align` | `left`\|`center`\|`right` | `center` | 配置 |
+
+---
+
+## Style（文字修飾。`text`=行単位 / `columns` のカラム=カラム単位）
+
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `bold` | bool | `false` | 強調 |
+| `underline` | int (0/1/2) | `0` | 下線（0=なし、1/2=ドット） |
+| `reverse` | bool | `false` | 白黒反転 |
+| `scaleWidth` | int (1–8) | `1` | 横倍角 |
+| `scaleHeight` | int (1–8) | `1` | 縦倍角 |
+| `font` | `A`\|`B` | `A` | フォント |
+
+> 能力依存: 非対応の修飾は消費者側で無視/縮退してよい（本リポジトリは指定を保持するのみ）。
+
+---
+
+## ルーティングチャネル（R/J/RJ・内部属性）
+
+各印字要素は backend の内部に R/J/RJ チャネル（ステーション）を持つ。これは出力の振り分けにのみ使い、**JSON スキーマには出力しない**。
+
+| チャネル | 意味 | `print_document`（本 JSON） | `journal_text`（プレーンテキスト） |
+|---|---|---|---|
+| `R` | レシートのみ | 含む | 含まない |
+| `J` | 電子ジャーナルのみ | 含まない | 含む |
+| `RJ`（既定） | 両方 | 含む | 含む |
+
+- backend（`AbstractReceiptData`）が要素を R/RJ → `print_document`、J/RJ → `journal_text` に振り分ける。
+- 戦略は `line_split`/`line_left`/… の `channel` 引数で指定する（既定 `RJ`）。例: JAN コード行を `channel="J"` にすると電子ジャーナルにのみ残る。
+- **本 JSON（`print_document`）は R/RJ のレシートビューのみ**であり、`channel` 属性は含まれない。
+
+---
+
+## 設計上のポイント
+
+- **桁揃えは消費者**。backend は `charsPerLine` を基準に意味カラム（left/mid/right）と位置を出力し、空白を焼き込まない。
+- **カラム単位の修飾が可能**（金額カラムだけ倍角 等）。カラム内スパン粒度は対象外。
+- 文字コードは UTF-8。対象デバイス文字セットへの変換は消費者が担う。
+
+---
+
+## 例
+
+- [examples/normal-sale.json](../examples/normal-sale.json) — 通常販売レシート（ロゴ・倍角タイトル・複数カラム明細・カラム単位修飾・バーコード・QR・カット）
+- [examples/builder-example.py](../examples/builder-example.py) — 上記を生成するアプリ側コード例

--- a/specs/139-receipt-print-schema/examples/builder-example.py
+++ b/specs/139-receipt-print-schema/examples/builder-example.py
@@ -1,0 +1,261 @@
+# Copyright 2026 TRIAL Company, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+#316 印字データ JSON（Level 1）— アプリ側コードの例示（設計用・未実装）
+
+本ファイルは「サンプル印字データ（examples/normal-sale.json）を、どのような
+アプリコードで生成するか」を示す**設計例示**であり、製品コードではない。
+
+Level 1 のポイント:
+  - 複数カラム行は columns 要素（left/mid/right）で**意味のまま**出力する
+    （空白を焼き込まない）。桁揃えは DeviceGW が metadata.charsPerLine を
+    基準に実施する（ADR-0003）。
+  - mid は startCol（左からの固定オフセット）。桁衝突時は mid.startCol で left を切詰め。
+  - style は text=行単位 / columns=カラム単位。
+
+構成:
+  A. JSON モデル（pydantic v2）       … kugel_common/receipt/print_document_model.py 相当
+  B. ビルダ（意味カラムをそのまま積む）
+  C. 戦略 build_print_document()      … normal-sale.json を 1:1 で生成
+  D. 既存フローへの差し込み（make_receipt_data の XML 経路を JSON へ置換）
+"""
+from __future__ import annotations
+
+from typing import Annotated, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_camel = ConfigDict(populate_by_name=True)
+
+
+# =====================================================================
+# A. JSON モデル（pydantic v2）— 出力は model_dump_json(by_alias=True) で camelCase
+# =====================================================================
+class Style(BaseModel):
+    # 各フィールドは省略可（未指定＝既定をレンダラ/DeviceGW が適用）。
+    model_config = _camel
+    bold: Optional[bool] = None
+    underline: Optional[int] = Field(None, ge=0, le=2)
+    reverse: Optional[bool] = None
+    scale_width: Optional[int] = Field(None, ge=1, le=8, alias="scaleWidth")
+    scale_height: Optional[int] = Field(None, ge=1, le=8, alias="scaleHeight")
+    font: Optional[Literal["A", "B"]] = None
+
+
+class TextElement(BaseModel):
+    model_config = _camel
+    type: Literal["text"] = "text"
+    value: str
+    align: Literal["left", "center", "right"] = "left"
+    style: Optional[Style] = None
+
+
+class Column(BaseModel):
+    model_config = _camel
+    slot: Literal["left", "mid", "right"]
+    value: str
+    start_col: Optional[int] = Field(None, alias="startCol")  # mid のみ必須
+    align: Optional[Literal["left", "center", "right"]] = None  # 既定: left/mid=left, right=right
+    style: Optional[Style] = None
+
+
+class ColumnsElement(BaseModel):
+    type: Literal["columns"] = "columns"
+    columns: list[Column]
+
+
+class RuledLineElement(BaseModel):
+    type: Literal["ruledLine"] = "ruledLine"
+    char: str = "-"
+
+
+class FeedElement(BaseModel):
+    type: Literal["feed"] = "feed"
+    lines: int
+
+
+class CutElement(BaseModel):
+    type: Literal["cut"] = "cut"
+    mode: Literal["full", "partial"] = "full"
+
+
+class BarcodeElement(BaseModel):
+    model_config = _camel
+    type: Literal["barcode"] = "barcode"
+    symbology: str
+    data: str
+    height: Optional[int] = None
+    module_width: Optional[int] = Field(None, alias="moduleWidth")
+    hri: Literal["none", "above", "below"] = "none"
+    align: Literal["left", "center", "right"] = "center"
+
+
+class QrcodeElement(BaseModel):
+    model_config = _camel
+    type: Literal["qrcode"] = "qrcode"
+    data: str
+    error_correction: Literal["L", "M", "Q", "H"] = Field("M", alias="errorCorrection")
+    module_size: Optional[int] = Field(None, alias="moduleSize")
+    align: Literal["left", "center", "right"] = "center"
+
+
+class LogoElement(BaseModel):
+    model_config = _camel
+    type: Literal["logo"] = "logo"
+    logo_id: str = Field(alias="logoId")
+    align: Literal["left", "center", "right"] = "center"
+
+
+Element = Annotated[
+    Union[
+        TextElement, ColumnsElement, RuledLineElement, FeedElement,
+        CutElement, BarcodeElement, QrcodeElement, LogoElement,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class Metadata(BaseModel):
+    model_config = _camel
+    document_type: str = Field("receipt", alias="documentType")
+    tenant_id: str = Field(alias="tenantId")
+    store_code: str = Field(alias="storeCode")
+    terminal_no: int = Field(alias="terminalNo")
+    transaction_no: Optional[int] = Field(None, alias="transactionNo")
+    receipt_no: Optional[int] = Field(None, alias="receiptNo")
+    business_date: Optional[str] = Field(None, alias="businessDate")
+    generated_at: str = Field(alias="generatedAt")
+    locale: str = "ja-JP"
+    chars_per_line: int = Field(48, alias="charsPerLine")  # 設計基準桁数（DeviceGW がこの基準で配置）
+
+
+class PrintDocument(BaseModel):
+    model_config = _camel
+    schema_version: str = Field("1.0", alias="schemaVersion")
+    metadata: Metadata
+    elements: list[Element] = Field(default_factory=list)
+
+    def to_json(self) -> str:
+        return self.model_dump_json(by_alias=True, exclude_none=True, indent=2)
+
+
+# =====================================================================
+# B. ビルダ（意味カラムをそのまま積む。空白の焼き込みはしない）
+# =====================================================================
+def L(value, style=None):                     # left カラム
+    return Column(slot="left", value=value, style=style)
+
+
+def M(value, start_col, style=None):          # mid カラム（開始位置指定）
+    return Column(slot="mid", value=value, start_col=start_col, style=style)
+
+
+def R(value, style=None):                     # right カラム
+    return Column(slot="right", value=value, style=style)
+
+
+class ReceiptDocBuilder:
+    """戦略から使う組み立てヘルパ（_add_* と同じ発想で要素を積む）。"""
+
+    def __init__(self):
+        self.elements: list[Element] = []
+
+    def text(self, value, align="left", style=None):
+        self.elements.append(TextElement(value=value, align=align, style=style))
+
+    def columns(self, *cols: Column):
+        self.elements.append(ColumnsElement(columns=list(cols)))
+
+    def rule(self, char="-"):
+        self.elements.append(RuledLineElement(char=char))
+
+    def feed(self, lines):
+        self.elements.append(FeedElement(lines=lines))
+
+    def cut(self, mode="full"):
+        self.elements.append(CutElement(mode=mode))
+
+    def logo(self, logo_id, align="center"):
+        self.elements.append(LogoElement(logo_id=logo_id, align=align))
+
+    def barcode(self, symbology, data, height=None, hri="none", align="center"):
+        self.elements.append(
+            BarcodeElement(symbology=symbology, data=data, height=height, hri=hri, align=align)
+        )
+
+    def qrcode(self, data, error_correction="M", module_size=None, align="center"):
+        self.elements.append(
+            QrcodeElement(data=data, error_correction=error_correction,
+                          module_size=module_size, align=align)
+        )
+
+
+# =====================================================================
+# C. 戦略：normal-sale.json を 1:1 で生成する build_print_document()
+#    現行 _add_* の「内容ロジック」は不変。line_split(a, b) を columns(L(a), R(b))
+#    に置換し、必要なら mid（M）や カラム単位 style を足すだけ。
+# =====================================================================
+def build_print_document_example() -> PrintDocument:
+    b = ReceiptDocBuilder()
+    emph = Style(bold=True, scale_height=2)
+
+    # ===== ヘッダ =====
+    b.logo("store-top-logo")
+    b.text("【 領 収 証 】", align="center", style=Style(scale_width=2, scale_height=2))
+    b.columns(L("レジNo. 1"), R("責# S001"))
+    b.text("2026年04月30日(木) 14:30")
+
+    # ===== ボディ =====
+    b.rule()
+    b.columns(L("おにぎり(鮭)"), R("150外"))
+    b.columns(L("お茶 500ml"), M("@108 x1", start_col=14), R("108外"))
+    b.rule()
+    b.columns(L("小計"), M("2点", start_col=10), R("258"))
+    b.columns(L("  消費税(外税8%)"), R("20"))
+    b.columns(L("合計", style=emph), R("\\278", style=emph))     # 合計はカラム単位で強調＋縦倍角
+    b.columns(L("お預り"), R("\\300"))
+    b.columns(L("お釣り"), R("\\22"))
+
+    # ===== フッタ＋新要素 =====
+    b.rule()
+    b.text("レシートNo. 100")
+    b.barcode("code128", "0012320260430000100", height=60, hri="below")
+    b.feed(1)
+    b.text("毎度ありがとうございます", align="center")
+    b.qrcode("https://survey.example.com/r/0012320260430000100")
+    b.feed(2)
+    b.cut("partial")
+
+    return PrintDocument(
+        metadata=Metadata(
+            tenant_id="tenant001", store_code="00123", terminal_no=1,
+            transaction_no=12345, receipt_no=100, business_date="2026-04-30",
+            generated_at="2026-04-30T14:30:00+09:00", chars_per_line=48,
+        ),
+        elements=b.elements,
+    )
+
+
+# =====================================================================
+# D. 既存フローへの差し込み（イメージ）
+#    AbstractReceiptData.make_receipt_data の XML 経路を JSON へ置換する。
+#
+#   def make_receipt_data(self, model) -> ReceiptData:
+#       print_document = self.build_print_document(model)         # ← make_receipt_text(XML) を置換
+#       journal_text   = self.make_journal_text(                  # 電子ジャーナルは維持
+#           self.generate_print_data(model))
+#       return ReceiptData(print_document=print_document, journal_text=journal_text)
+# =====================================================================
+if __name__ == "__main__":
+    print(build_print_document_example().to_json())

--- a/specs/139-receipt-print-schema/examples/normal-sale.json
+++ b/specs/139-receipt-print-schema/examples/normal-sale.json
@@ -1,0 +1,206 @@
+{
+  "schemaVersion": "1.0",
+  "metadata": {
+    "documentType": "receipt",
+    "tenantId": "tenant001",
+    "storeCode": "00123",
+    "terminalNo": 1,
+    "transactionNo": 12345,
+    "receiptNo": 100,
+    "businessDate": "2026-04-30",
+    "generatedAt": "2026-04-30T14:30:00+09:00",
+    "locale": "ja-JP",
+    "charsPerLine": 48
+  },
+  "elements": [
+    {
+      "type": "logo",
+      "logoId": "store-top-logo",
+      "align": "center"
+    },
+    {
+      "type": "text",
+      "value": "【 領 収 証 】",
+      "align": "center",
+      "style": {
+        "scaleWidth": 2,
+        "scaleHeight": 2
+      }
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "レジNo. 1"
+        },
+        {
+          "slot": "right",
+          "value": "責# S001"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "value": "2026年04月30日(木) 14:30",
+      "align": "left"
+    },
+    {
+      "type": "ruledLine",
+      "char": "-"
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "おにぎり(鮭)"
+        },
+        {
+          "slot": "right",
+          "value": "150外"
+        }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "お茶 500ml"
+        },
+        {
+          "slot": "mid",
+          "value": "@108 x1",
+          "startCol": 14
+        },
+        {
+          "slot": "right",
+          "value": "108外"
+        }
+      ]
+    },
+    {
+      "type": "ruledLine",
+      "char": "-"
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "小計"
+        },
+        {
+          "slot": "mid",
+          "value": "2点",
+          "startCol": 10
+        },
+        {
+          "slot": "right",
+          "value": "258"
+        }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "  消費税(外税8%)"
+        },
+        {
+          "slot": "right",
+          "value": "20"
+        }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "合計",
+          "style": {
+            "bold": true,
+            "scaleHeight": 2
+          }
+        },
+        {
+          "slot": "right",
+          "value": "\\278",
+          "style": {
+            "bold": true,
+            "scaleHeight": 2
+          }
+        }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "お預り"
+        },
+        {
+          "slot": "right",
+          "value": "\\300"
+        }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        {
+          "slot": "left",
+          "value": "お釣り"
+        },
+        {
+          "slot": "right",
+          "value": "\\22"
+        }
+      ]
+    },
+    {
+      "type": "ruledLine",
+      "char": "-"
+    },
+    {
+      "type": "text",
+      "value": "レシートNo. 100",
+      "align": "left"
+    },
+    {
+      "type": "barcode",
+      "symbology": "code128",
+      "data": "0012320260430000100",
+      "height": 60,
+      "hri": "below",
+      "align": "center"
+    },
+    {
+      "type": "feed",
+      "lines": 1
+    },
+    {
+      "type": "text",
+      "value": "毎度ありがとうございます",
+      "align": "center"
+    },
+    {
+      "type": "qrcode",
+      "data": "https://survey.example.com/r/0012320260430000100",
+      "errorCorrection": "M",
+      "align": "center"
+    },
+    {
+      "type": "feed",
+      "lines": 2
+    },
+    {
+      "type": "cut",
+      "mode": "partial"
+    }
+  ]
+}

--- a/specs/139-receipt-print-schema/plan.md
+++ b/specs/139-receipt-print-schema/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: device-agnostic な印字データスキーマ（XML 撤去・JSON 化）
+
+**Branch**: `139-receipt-print-schema` | **Date**: 2026-06-07 | **Spec**: [spec.md](./spec.md)
+**Related Issue**: [#139](https://github.com/kugel-masa/kugelpos-backend/issues/139)
+**派生元**: stpos-backend `316-device-print-schema`
+
+## Summary
+
+`AbstractReceiptData`（kugel_common）が `receipt_text` に入れている印字データの中身を XML→device-agnostic な JSON 文字列（`print_document` スキーマ）へ移行する。**フィールド名 `receipt_text`・`str` 型は据え置き**、中身のみ変更。`journal_text` は維持。変更は kugel_common に閉じ、cart/terminal/journal/report のコードは無改変。
+
+`AbstractReceiptData` を継承する印字生成器は 7 つ（cart 取引×1、terminal 開閉店/現金×2、report 帳票 sales/item/payment/category×4）。**いずれも `line_split`/`line_center`/`line_left`/`line_right`/`line_boarder` と整形ヘルパ（fixed_*/comma/yen 等）のみで Page を組み立てており、`Line()`/`Page()` の直接構築や `tables` は使っていない**（調査で確認）。この事実を利用し、基底のヘルパを**後方互換シム**として再実装することで、**7 生成器のレシート内容を一切変えずに**出力形式だけを XML→JSON へ移行する。
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: FastAPI, Pydantic v2, Motor（async MongoDB）, Dapr（pub/sub）
+**撤去する依存**: `pydantic-xml`（`receipt_data_model.py` の XML モデルでのみ使用）
+**Storage**: MongoDB（`tranlog`/`journal_document`/`open_close_log`/`cash_in_out_log`/report 各 document）。`receipt_text:str`（不変）の中身を XML→JSON 文字列へ
+**Testing**: pytest + pytest-asyncio（unit / integration / e2e）
+**Project Type**: Microservices（kugel_common 共通 + cart/terminal/journal/report）
+
+## 設計方針（Converter + 後方互換シム）
+
+### 1. 新規モデル `kugel_common/receipt/print_document_model.py`
+[contracts/print-document.schema.md](./contracts/print-document.schema.md) を pydantic v2 で実装（`examples/builder-example.py` のモデル定義を流用）。
+- `Style`（bold/underline/reverse/scaleWidth/scaleHeight/font）
+- `Column`（slot/value/startCol/align/style）
+- 要素: `TextElement`/`ColumnsElement`/`RuledLineElement`/`FeedElement`/`CutElement`/`BarcodeElement`/`QrcodeElement`/`ImageElement`/`LogoElement`（`type` discriminator のユニオン）
+- `Metadata`（documentType/tenantId/storeCode/terminalNo/transactionNo/receiptNo/businessDate/generatedAt/locale/charsPerLine）
+- `PrintDocument`（schemaVersion/metadata/elements）。出力は `model_dump(by_alias=True, exclude_none=True)`（camelCase dict）
+
+### 2. `receipt_data_model.py` の作り替え（XML 撤去）
+- `pydantic-xml`（`BaseXmlModel`/`to_xml`/`PrintData`）を撤去。
+- `Page`（`lines: list[Element]`）と `Line`（= Element 型エイリアス、型注釈の後方互換用）、`Constants`（既存定数）を残す。
+- `tables` は誰も使っていないため廃止。
+
+### 3. `AbstractReceiptData` の改修（基底）
+- `make_receipt_data(model) -> ReceiptData`:
+  1. `page = generate_print_data(model)`（既存どおり header/body/footer が Page.lines に Element を積む）
+  2. `print_document = build_print_document(model, page.lines)`（Metadata 構築 + camelCase dict 化）
+  3. `journal_text = render_journal_text(page.lines, self.width)`（**現行 `to_text` と同一出力**）
+  4. `return ReceiptData(print_document=print_document, journal_text=journal_text)`
+- **`make_receipt_text`（XML）と `to_xml` 経路を削除**。
+- 後方互換シム（戻り値を Element に変更、引数・呼び出し側は不変）:
+  - `line_left/center/right(text)` → `TextElement(value=text, align=...)`
+  - `line_split(a, b)` → `ColumnsElement(columns=[Column(left, a), Column(right, b)])`
+  - `line_boarder()` → `RuledLineElement(char="-")`
+- Metadata は共通属性を `getattr` で抽出（documentType 既定 "receipt"、`charsPerLine = self.width`、generatedAt = `generate_date_time` か app time）。report 生成器は将来 documentType を上書き可能にする（任意）。
+
+### 4. `journal_text` 無回帰の担保
+`render_journal_text` は現行 `to_text` を Element 入力に移植し、**バイト等価**を保つ:
+- `TextElement` center/left/right → `TextHelper.fixed_center/left/right(value, width)`
+- `ColumnsElement[left,right]` → 現行 SPLIT と同じく `fixed_left(left, width - wcswidth(right) - 1, truncate=True) + " " + right`
+- `RuledLineElement` → `"".center(width, char)`
+- 新要素（feed/cut/barcode/qrcode/image/logo）は本フィーチャーの production 生成器では使用しないため journal 出力に現れない（showcase は examples/ のみ）。将来 production で使う場合の journal 表現は別途定義。
+
+> **重要な判断**: production の 7 生成器のレシート**内容は変更しない**（行・文言・順序・桁を維持）。ロゴ/倍角/バーコード/QR 等の拡張表現は **スキーマと examples/（normal-sale.json・builder-example.py）で実証**する。これにより SC-002（論理等価）/SC-005（journal 無回帰）を確実に満たす。各生成器を意味カラム（mid 利用）へ深掘り改修するのは、スキーマ変更を伴わない後続作業として generator 単位で実施可能。
+
+### 5. フィールド据え置き（`receipt_text:str`・名前/型不変）
+- `BaseTransaction`（kugel_common）: `receipt_text: Optional[str]` は**不変**。`ReceiptData.receipt_text` も `str`。`make_receipt_data` が `json.dumps(build_print_document(...), ensure_ascii=False)` で **JSON 文字列**を入れる。
+- cart / terminal / journal / report: **コード無改変**。`receipt_text`（`str`）の中身が XML→JSON 文字列に変わるだけ。document・schema・transformer・戦略・テストは元のまま。
+- pub/sub: cart の tranlog ペイロードはフィールド構成不変。`receipt_text` の中身のみ JSON 文字列に。
+
+### 6. R/J/RJ チャネル（ステーション）— 追補 2026-06-07
+- `print_document_model.py` に共通基底 `PrintElement` を導入し、`channel: Literal["R","J","RJ"] = Field("RJ", exclude=True)` を全要素へ付与（**JSON 出力からは除外**＝内部ルーティング属性）。
+- `AbstractReceiptData`: `build_print_document` は `channel in {R, RJ}` の要素のみを `print_document` に含め、`render_journal_text` は `channel in {J, RJ}` のみを描画。`line_split`/`line_center`/`line_left`/`line_right`/`line_boarder` に `channel` 引数を追加（既定 `RJ`）。
+- 既定 RJ のため既存戦略のレシート/ジャーナル内容は不変（**機能追加のみ**）。commons に routing 単体テスト（`tests/unit/test_receipt_routing.py`）を追加。
+
+## Constitution Check
+
+| 項目 | 状態 | 備考 |
+|---|---|---|
+| 成果物（spec/plan/tasks/docs）が日本語 | PASS | 本フィーチャーの speckit 文書はすべて日本語 |
+| コード内コメント・ログが英語 | 実装時遵守 | 新モデル・基底改修・各サービスで英語コメント徹底 |
+
+## Project Structure
+
+```text
+specs/139-receipt-print-schema/
+├── spec.md
+├── plan.md                 # 本ファイル
+├── tasks.md
+├── contracts/print-document.schema.md
+├── examples/normal-sale.json
+├── examples/builder-example.py
+└── checklists/requirements.md
+
+services/commons/src/kugel_common/receipt/
+├── print_document_model.py   # 新規（スキーマ実装）
+├── receipt_data_model.py     # 改修（XML 撤去・Page/Line/Constants 維持）
+└── abstract_receipt_data.py  # 改修（XML 撤去・シム・JSON+journal 生成）
+```
+
+## フェーズ（実装順）
+
+1. **commons（唯一の変更箇所）**: `print_document_model.py` 追加 → `receipt_data_model.py` 改修（XML 撤去）→ `abstract_receipt_data.py` 改修（`make_receipt_data` が `receipt_text` に JSON 文字列を入れる・channel ルーティング）。`base_tranlog.py` は不変。commons unit テスト + routing テスト。
+2. **cart / terminal / journal / report**: コード変更なし（`receipt_text` の中身が JSON 文字列に変わるのみ）。新 commons wheel を再ビルド・再インストールし、既存 unit/integration/e2e が無改変で pass することを確認。
+3. **検証**: 全サービス unit/integration/e2e。XML 生成経路が残っていないことを grep で確認。
+
+## リスクと緩和
+
+| リスク | 緩和 |
+|---|---|
+| journal_text 回帰 | render_journal_text を to_text とバイト等価に移植。cart/terminal/report の既存 unit テストで確認 |
+| `receipt_text` 参照漏れ（146 箇所） | grep ベースで service ごとに潰し、最後に全 grep で 0 を確認（テスト除く production コード） |
+| 歴史データ（XML）の読み出し | `receipt_text` は `str` のまま。旧 XML も新 JSON も同一フィールドに入るためデシリアライズは壊れない。読み出し側は中身の format を判別（先頭が `{`=JSON / `<`=XML）すればよい |
+| pub/sub 購読側の不整合 | cart 発行と journal/report 購読を同一リリースで切替（ハードカットオーバー） |
+
+## Success Criteria 対応
+
+- SC-001/003: `print_document_model` のスキーマ + 要素テスト
+- SC-002/005: production 生成器の内容不変 + journal バイト等価
+- SC-004: 実装後 `grep -r receipt_text services/*/app` が production コードで 0
+- SC-006: 全 unit/integration テスト パス

--- a/specs/139-receipt-print-schema/spec.md
+++ b/specs/139-receipt-print-schema/spec.md
@@ -1,0 +1,323 @@
+# Feature Specification: device-agnostic な印字データスキーマ（XML 撤去・JSON 化・表現力拡張）
+
+**Feature Branch**: `139-receipt-print-schema`
+**Created**: 2026-06-07
+**Status**: Draft
+**SPEC_TYPE**: functional
+**Issue**: [#139](https://github.com/kugel-masa/kugelpos-backend/issues/139)
+**派生元**: stpos-backend `316-device-print-schema`（流用・kugelpos #139 向けに再スコープ）
+
+---
+
+## 概要
+
+POS のレシート/ジャーナル印字において、現在 backend（kugel_common 経由で cart / terminal / report）が `receipt_text` に入れている **XML 形式の印字データの中身を、OPOS や特定プリンタ機種に依存しない device-agnostic な JSON（`print_document` スキーマ）へ全面移行**する。**フィールド名（`receipt_text`）・型（`str`）は据え置き、中身（テキスト）を XML→JSON へ変える**。あわせて表現力を拡張する（位置・倍角等の文字修飾・ロゴ・画像・バーコード・QR・行送り・レシートカット）。
+
+本フィーチャーのスコープは **backend（本リポジトリ）が生成する印字データの「形式」と「生成ロジック」** に限定する。印字データを実機コマンドへ変換・描画する device-gateway 相当の処理は本リポジトリのスコープ外であり、最終描画は印字データの消費者（frontend / device）の責務とする（Issue #139）。
+
+具体的には:
+
+1. 印字データを **device-agnostic な意味表現** として再設計し表現力を拡張する。
+2. 形式を **XML から JSON へハードカットオーバー**する（並行運用・XML フォールバックなし）。
+3. backend は **意味カラム**（各カラムの値・位置・修飾）を出力し、桁揃え（空白計算・配置）と実機描画は **消費者の責務**とする。
+4. `journal_text`（電子ジャーナル・プレーンテキスト）は **維持** する。
+
+これにより backend は OPOS 仕様・プリンタ機種差から分離され、印字機能の拡張（ロゴ・画像・バーコード等）がデータ表現の追加だけで可能になる。
+
+---
+
+## Clarifications
+
+### Session 2026-06-07
+
+- Q: stpos #316 の DeviceGW API 契約（文書印字 API・冪等性・状態/能力照会・OPOS エラー正規化）と frontend パススルー契約は本フィーチャーに含めるか？ → A: **スコープ外に整理**。本フィーチャーの成果物は backend の印字データ JSON スキーマ（kugel_common）と生成ロジック（cart/terminal/report 戦略）まで。実機変換・描画・非同期印字ジョブ・冪等性・能力照会は消費者（frontend/device）の責務とし、Out of Scope に記載のうえ短く参照するに留める（Issue #139 の Out of scope に一致）。
+- Q: terminal の開閉店/現金レシートの JSON 化を本フィーチャーに含めるか？ → A: **含める**。kugel_common の XML 生成廃止（ハードカットオーバー）に伴い必須。cart と同時に JSON 化する。
+- Q: kugelpos に #73 相当の R/J/RJ チャネル振り分けは存在するか？ → A: **元の実装には存在しなかった**（`receipt_text`(XML) と `journal_text`(plain) は同一ツリーから別レンダリングするだけ）。**当初は導入しない方針だったが、後続の合意で R/J/RJ チャネルを導入**（下記 2026-06-07 追補・FR-007 改訂）。
+- 追補（2026-06-07）: **R/J/RJ チャネル（ステーション）指定をサポートする**。各印字要素に `channel`（R=レシートのみ / J=電子ジャーナルのみ / RJ=両方・既定）を持たせ、backend が**内部で**振り分ける（R/RJ→レシート、J/RJ→`journal_text`）。チャネルは内部ルーティング属性で **JSON 出力には現れない**。既定 RJ のため既存戦略の内容は不変（機能追加のみ。production 戦略でのチャネル実利用は後続）。
+- 確定（2026-06-07・最重要）: **フィールド名は `receipt_text`、型は `str` のまま据え置く**。新フィールド `print_document` は追加しない。**`receipt_text` の中身（テキスト）を XML 文字列 → JSON 文字列に変える**だけ（JSON は `print_document` スキーマ＝`schemaVersion`/`metadata`/`elements` を `json.dumps` した文字列）。`journal_text` も従来どおり。これにより `tranlog`／各ログ文書／API レスポンス／pub-sub の**フィールド名・型は一切変わらず**、cart/terminal/journal/report の document・schema・transformer は**無改変**。変更は kugel_common（生成ロジック）に閉じる。`print_document` という語は本仕様では**保存フィールド名ではなく JSON スキーマ（印字文書）の呼称**として用いる。
+- Q: XML→JSON 移行の形は？ → A: **ハードカットオーバー（XML を残さず JSON のみ）**。並行運用・XML フォールバックは設けない。理由＝二重保持の容量回避（pub-sub / sync / 保存）。過去データ（XML を持つ tranlog / journal_document）はマイグレーションせず、読み出し側は XML・JSON 混在を許容する。
+- Q: 文字コードは？ → A: パイプラインは **UTF-8** のまま通す。対象デバイスの文字セット（例 Shift-JIS）への変換とマップ不能文字の代替は消費者/device の責務（本リポジトリは UTF-8 維持）。
+
+---
+
+## 影響するサービス
+
+> **重要**: 変更は **kugel_common（生成ロジック）に閉じる**。`receipt_text` のフィールド名・`str` 型・スキーマは全サービスで不変で、**中身が XML 文字列→JSON 文字列に変わるだけ**。よって cart/terminal/journal/report のコード（document・schema・transformer・戦略）は**無改変**。
+
+| サービス名 | 変更の種類 | 変更の概要 |
+|---|---|---|
+| kugel_common（共通ライブラリ） | 変更 | 意味要素ベースの印字データモデル（`print_document` スキーマ）を追加。`AbstractReceiptData` の **XML 生成経路（`PrintData.to_xml`・`make_receipt_text`）を撤去**し、`receipt_text` に **JSON 文字列**を入れる（`json.dumps(print_document)`）。`journal_text` 生成は維持。`BaseTransaction.receipt_text` は **`Optional[str]` のまま**（型・名前不変） |
+| cart | 影響なし（中身のみ変化） | 戦略（`ReceiptDataSample`）・`tranlog`・Cart API レスポンス・pub/sub ペイロードは**無改変**。`receipt_text` の中身が XML→JSON 文字列に変わる |
+| terminal | 影響なし（中身のみ変化） | 開閉店/現金レシート戦略・`open_close_log`／`cash_in_out_log`・API は**無改変**。`receipt_text` の中身が JSON 文字列に |
+| journal | 影響なし（中身のみ変化） | 監査保存・API 配信は**無改変**。保存する `receipt_text` の中身が JSON 文字列に |
+| report | 影響なし（中身のみ変化） | 帳票生成器（sales/item/payment/category）・帳票ドキュメント・API は**無改変**。`receipt_text` の中身が JSON 文字列に |
+
+**影響なしのサービス（確認済み）**: account, master-data, stock。
+
+---
+
+## 変更する Pub/Sub トピック
+
+| トピック | 変更の種類 | 発行者 | 購読者 | 変更の概要 |
+|---|---|---|---|---|
+| `tranlog_report`（`topic-tranlog`/`-cloud`） | **スキーマ変更（破壊的）** | cart | report, journal, stock | `tranlog` ペイロードのフィールド（`receipt_text`/`journal_text`）は不変。`receipt_text` の中身が XML→JSON 文字列に変わるのみ（購読側のコード改修は不要） |
+
+> トピックのパブリッシャー/サブスクライバー割り当て・ペイロードのフィールド構成は変更しない。変更するのは **`receipt_text` の中身**（XML→JSON 文字列）。Edge↔Cloud sync のペイロードも中身が変わる（XML 撤去により容量は削減方向）。
+
+---
+
+## 変更するインターフェース
+
+| インターフェース | 変更の種類 | 影響するサービス | 後方互換性 |
+|---|---|---|---|
+| 印字データモデル（kugel_common） | 置換（JSON 新設・XML 廃止） | cart, terminal, report, journal | **破壊的** |
+| Cart API レスポンス（`POST /carts/{cart_id}/bill` 等） | フィールド置換 | cart | 中身のみ変化（フィールド不変。`receipt_text` の中身が XML→JSON 文字列。`journal_text` 維持） |
+| Terminal API レスポンス（開閉店/現金入出金） | フィールド置換 | terminal | **破壊的**（同上） |
+| `tranlog` ドキュメント（共有・MongoDB/pub-sub/sync） | フィールド置換 | cart, report, journal | **破壊的** |
+| `journal_document` / `open_close_log` / `cash_in_out_log` | フィールド置換 | journal, terminal, report | **破壊的**（保存する受領レシートを XML→JSON へ） |
+| 帳票（report）API レスポンス | フィールド置換 | report | **破壊的**（`receiptText` の中身が JSON へ） |
+
+---
+
+## 後方互換性
+
+**方針：ハードカットオーバー（XML を残さず JSON のみへ全面切替）。理由＝保持・配信・sync するデータ容量の削減。**
+
+- **スキーマ**: フィールド名・型は不変。`receipt_text` の中身を XML→JSON 文字列へ変更。`journal_text` は維持。
+- **API**: フィールドは不変。`receipt_text` の中身が JSON 文字列に変わる。消費者は中身を JSON として解釈する。
+- **既存データ**: 過去の `tranlog`／`journal_document` 等は `receipt_text`(XML) のまま残す（マイグレーションしない）。読み出し側は **歴史データ=XML・新規=JSON の混在**を許容すること。
+- **リスク**: 単一リリースでの全面切替のため、cart/terminal/journal/report の同時整合が必須。
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 取引確定時に device-agnostic な JSON 印字データを生成 (Priority: P1)
+
+会計係が取引を確定すると、backend（cart）は OPOS にもプリンタ機種にも依存しない、意味単位で構造化された JSON 印字データ（`print_document`）を生成して返す。消費者はその内容を解釈・加工せずに描画/転送できる。
+
+**独立テスト可能性**: テスト用取引でレシートを生成し、返却 JSON が定義済みスキーマに適合し、移行前の `receipt_text`(XML) と論理的に等価な内容（同一の行・順序・文言）であることを検証する。
+
+**Affected Services**: kugel_common, cart
+
+#### Acceptance Criteria
+1. **Given** 通常販売取引, **When** 取引を確定する, **Then** Cart レスポンスと `tranlog` に新スキーマ準拠の `print_document`(JSON) が含まれる
+2. **Given** 同一取引, **When** JSON と移行前 XML を比較する, **Then** 両者が表現する印字行（文言・順序）が論理的に一致する
+3. **Given** JSON 印字データ, **When** スキーマ検証を行う, **Then** `schemaVersion` を含むスキーマに完全適合する
+4. **Given** 取引確定後の `tranlog` / Cart レスポンス, **When** フィールドを確認する, **Then** `receipt_text`(XML) が**含まれず**、`journal_text` は従来どおり生成される
+
+---
+
+### User Story 2 - 印字の修飾・位置を表現できる (Priority: P1)
+
+レシート設計者が、各印字要素に対し位置（左/中央/右）と文字修飾（倍角縦・倍角横・強調・下線・白黒反転・フォント切替）を指定でき、その指定が JSON に保持される。
+
+**独立テスト可能性**: 各修飾・各位置を指定した要素を生成し、JSON 上で対応する属性が保持されることを検証する。
+
+**Affected Services**: kugel_common, cart
+
+#### Acceptance Criteria
+1. **Given** 中央寄せ・倍角（縦横）・強調を指定したテキスト要素, **When** 生成する, **Then** 位置=中央・倍角縦横・強調の各属性が要素に保持される
+2. **Given** 左/中央/右の各位置指定, **When** 生成する, **Then** それぞれが区別可能な値として保持される
+3. **Given** 修飾を指定しない要素, **When** 生成する, **Then** 既定（位置=左・等倍・修飾なし）が適用される
+
+---
+
+### User Story 3 - ロゴ・画像・バーコード・QR・行送り・カットを表現できる (Priority: P1)
+
+レシート設計者が、ロゴ・画像・バーコード・QR・行送り・レシートカットを印字データ上で指定でき、消費者がそれらを実機に出力できる形で保持される。
+
+**独立テスト可能性**: 各要素を含む印字データを生成し、JSON 上で各要素タイプと必須パラメータが表現されることを検証する。
+
+**Affected Services**: kugel_common, cart
+
+#### Acceptance Criteria
+1. **Given** バーコード要素（シンボロジー・データ・高さ・HRI 位置）, **When** 生成する, **Then** それらが保持される
+2. **Given** QR 要素（データ・誤り訂正レベル・モジュールサイズ）, **When** 生成する, **Then** それらが保持される
+3. **Given** 画像要素（base64 または URL 参照・位置）, **When** 生成する, **Then** ソース種別とデータが保持される
+4. **Given** ロゴ要素（登録ロゴ識別子）, **When** 生成する, **Then** ロゴ識別子が保持される
+5. **Given** 行送り（行数）／レシートカット（全/部分）要素, **When** 生成する, **Then** それぞれが区別可能な要素として保持される
+
+---
+
+### User Story 4 - 複数カラム行を意味情報として出力できる (Priority: P1)
+
+レシート設計者が、1 行内に複数カラム（`left`/`mid`/`right`）を、空白を焼き込まない**意味情報**として出力できる。`mid` は左からの固定オフセット `startCol` で開始位置を指定する。各カラムは独立した値・位置・修飾を持てる（例：金額カラムのみ倍角）。桁揃え（空白計算・配置）は消費者の責務とする。
+
+**独立テスト可能性**: `left`/`mid`/`right` の組み合わせを含む行を生成し、JSON 上でカラム値・`startCol`・カラム単位 `style` が保持され、整形済みテキスト（空白埋め込み）になっていないことを検証する。
+
+**Affected Services**: kugel_common, cart
+
+#### Acceptance Criteria
+1. **Given** `left`+`right` のみ／`left`+`mid`+`right` の行, **When** 生成する, **Then** 各カラムが意味情報として保持される
+2. **Given** `mid` カラム, **When** 生成する, **Then** `startCol`（半角換算・`charsPerLine` 基準）で開始位置が保持される
+3. **Given** カラム単位 `style`（倍角等）, **When** 生成する, **Then** 各カラムに独立して保持される
+4. **Given** いずれのカラムも, **When** 生成する, **Then** 整形済みテキスト（空白埋め込み済み）ではなく値そのものが保持される
+
+---
+
+### Edge Cases
+
+- すべての行を含む取引で `journal_text`（プレーンテキスト）は従来どおり生成されるか？
+- 取消取引（VoidSales/VoidReturn）の印字データはどう表現されるか？（現状は「取引中止」レシートを生成。挙動を回帰なく維持する）
+- 倍角・カラム単位修飾を含む `print_document` がスキーマ検証に適合するか？
+- 文字コード: UTF-8 のまま JSON へ載るか（Shift-JIS 変換は消費者責務で本リポジトリは変換しない）。
+- 歴史データ（XML を持つ `tranlog`/`journal_document`）を読み出し側がエラーなく扱えるか。
+
+---
+
+## Functional Requirements *(mandatory)*
+
+### FR-001: device-agnostic な印字データスキーマの定義
+**Description**: OPOS・特定プリンタ機種に依存しない、意味単位で構造化された印字データスキーマ（`print_document`）を kugel_common に定義する。スキーマはバージョン識別子（`schemaVersion`）・文書メタデータ・順序付き印字要素列を持つ。
+**Affected Services**: kugel_common
+**Priority**: P1
+**Acceptance Criteria**:
+- スキーマがバージョン識別子（`schemaVersion`）を持つこと
+- 印字要素が出現順序を保持する列として表現されること
+- 文書メタデータ（文書種別・テナント/店舗/端末識別・取引/レシート番号・営業日・生成日時・ロケール・`charsPerLine`＝設計基準桁数）を表現できること
+
+### FR-002: テキスト要素と位置・文字修飾
+**Description**: テキスト要素に位置（左/中央/右）と文字修飾（倍角縦・倍角横・強調・下線・白黒反転・フォント選択）を指定できること。
+**Affected Services**: kugel_common, cart
+**Priority**: P1
+**修飾の粒度（設計注記）**:
+- 修飾の粒度は **`text` 要素＝行単位 / `columns` 要素＝カラム単位**。1 カラム内の一部だけの修飾（スパン粒度）は本フィーチャーのスコープ外。
+- 位置（align）は行/要素レベル属性。倍角の倍率は 1〜8。
+- 修飾はレシート（視覚）専用。`journal_text`（プレーンテキスト）には反映しない。
+**Acceptance Criteria**:
+- 位置（左/中央/右）を指定でき、未指定時は既定値が適用されること
+- 倍角（縦・横を独立指定、1〜8）・強調・下線・白黒反転・フォント選択を指定できること
+- 修飾を指定しない場合、等倍・修飾なしが既定となること
+
+### FR-003: 複数カラム行（left/mid/right・意味情報）
+**Description**: 1 行内に複数カラム（`left`=左端起点 / `mid`=`startCol` 起点 / `right`=右端終端）を表現する `columns` 要素を持つこと。各カラムは独立した値・位置・`style` を持つ。カラムは空白を詰めた整形済みテキストにせず**意味情報**として出力する。桁揃えは消費者の責務。
+**Affected Services**: kugel_common, cart
+**Priority**: P1
+**Acceptance Criteria**:
+- 1 行で `left`/`mid`/`right` の任意組み合わせを表現できること
+- `mid` は左からの固定オフセット `startCol`（半角換算・`charsPerLine` 基準）で開始位置を指定できること
+- 各カラムに独立して文字修飾を指定できること
+- カラムが整形済みテキストではなく意味情報として出力されること
+
+### FR-004: 罫線・行送り・レシートカット要素
+**Affected Services**: kugel_common, cart
+**Priority**: P1
+**Acceptance Criteria**:
+- 罫線要素（使用文字）を表現できること
+- 行送り要素（行数）を表現できること
+- レシートカット要素（全カット/部分カット）を表現できること
+
+### FR-005: バーコード・QRコード要素
+**Affected Services**: kugel_common, cart
+**Priority**: P1
+**Acceptance Criteria**:
+- 代表的なシンボロジー（JAN/EAN・CODE128・CODE39・ITF 等）を指定できること
+- バーコードの高さ・HRI 位置（なし/上/下）を指定できること
+- QR の誤り訂正レベル・モジュールサイズを指定できること
+
+### FR-006: 画像・ロゴ要素
+**Affected Services**: kugel_common, cart
+**Priority**: P1
+**Acceptance Criteria**:
+- 画像要素がソース種別（base64/URL）とデータ、位置を表現できること
+- ロゴ要素が登録ロゴ識別子を表現できること
+
+### FR-007: R/J/RJ チャネル（ステーション）による振り分け
+**Description**: 各印字要素に R/J/RJ チャネルを指定でき、backend が**内部で**振り分ける。R/RJ → レシート内容（`print_document`）、J/RJ → 電子ジャーナル `journal_text`。未指定時は両方（RJ）。チャネルは backend のルーティング属性であり **`print_document`(JSON) には出力しない**（消費者はレシートビューのみを受領）。`journal_text` は従来どおり回帰なく維持する。
+**Affected Services**: kugel_common, cart, terminal, report
+**Priority**: P1
+**Acceptance Criteria**:
+- 各印字要素に R/J/RJ チャネルを指定でき、未指定時は両方（RJ）となること
+- `print_document` が R/RJ 要素のみを含むこと（J 要素は含まない）
+- `journal_text` が J/RJ 要素のみから生成されること（R 要素は含まない）
+- チャネル属性が `print_document`(JSON) の出力に**現れないこと**（内部ルーティングのみ）
+- 既定 RJ により、チャネル未使用の既存戦略のレシート/ジャーナル内容が回帰しないこと
+
+### FR-008: JSON 形式での出力（XML 置換）
+**Description**: `receipt_text`（フィールド名・`str` 型は維持）の**中身を XML 文字列から JSON 文字列へ**変更する。JSON は `print_document` スキーマを `json.dumps` した文字列。XML（`PrintData.to_xml`）生成経路は撤去する。`journal_text` は維持する。
+**Affected Services**: kugel_common
+**Priority**: P1
+**Acceptance Criteria**:
+- `receipt_text` が `print_document` スキーマ準拠の JSON 文字列を保持すること（フィールド名・`str` 型は不変）
+- XML を生成・保存・配信する経路が製品コードに残っていないこと
+- `journal_text` は従来どおり生成・維持されること
+
+### FR-009: 全サービスの印字生成器の JSON 化（cart/terminal/report）
+**Description**: `AbstractReceiptData` を継承する全 7 生成器（cart 取引×1、terminal 開閉店/現金×2、report 帳票 sales/item/payment/category×4）が `print_document` を出力すること。基底の XML 経路撤去に伴い全生成器が一貫して JSON を出力する。
+**Affected Services**: kugel_common, cart, terminal, report
+**Priority**: P1
+**Acceptance Criteria**:
+- 7 生成器すべてが `print_document` を出力すること
+- 既存の `line_*` 系ヘルパ（line_split/center/left/right/boarder）が新スキーマ上で機能すること（後方互換シム）
+- 各生成器の `journal_text` 出力が回帰しないこと
+
+### FR-010: 協調リリースと歴史データの取り扱い
+**Description**: 本フィーチャーは破壊的変更（XML 撤去）であり後方互換は維持しない。協調リリースの整合と歴史データの読み出し許容を要件とする。
+**Affected Services**: kugel_common, cart, terminal, report, journal
+**Priority**: P1
+**Acceptance Criteria**:
+- XML を生成・保存・配信する経路が製品コードに残っていないこと（kugel_common/cart/terminal/report）
+- journal/report が `print_document`(JSON) を正しく保存・参照できること
+- 過去に保存済みの `receipt_text`(XML) を持つ `tranlog`／ログ文書を、読み出し側がエラーなく扱えること（混在許容）
+
+---
+
+## Non-Functional Requirements
+
+| 項目 | 要件 | 備考 |
+|---|---|---|
+| パフォーマンス | JSON 印字データ生成によるレシート生成時間の増加が ±10% 以内 | 行数に比例する線形処理 |
+| 容量 | XML 撤去により `tranlog`／pub-sub／sync／ログ文書のレシート表現が JSON 単一となり二重保持が無いこと | 本切替の主目的 |
+| 互換性 | 新規フィールドはすべてデフォルト値を持ち、既存データのデシリアライズを壊さないこと | 歴史データ読み出し許容 |
+
+---
+
+## Data Model Changes
+
+- **新規（kugel_common）**: device-agnostic 印字データモデル `PrintDocument`（文書メタデータ＋順序付き印字要素列）。要素は種別（text/columns/ruledLine/feed/cut/barcode/qrcode/image/logo）で区別され、各種別が固有パラメータと共通の修飾・位置属性を持つ。出力は camelCase JSON（消費者向け契約）。
+- **撤去（kugel_common）**: XML を生成する経路（`PrintData.to_xml`・`make_receipt_text`）を廃止。`journal_text` 生成（`to_text` 相当）は維持。
+- **変更（kugel_common の生成ロジックのみ）**: `receipt_text`（`str`）の中身を XML→JSON 文字列に変更。`tranlog`／`journal_document`／`open_close_log`／`cash_in_out_log`／API レスポンスの**フィールド名（`receipt_text`）・型（`str`）は不変**。cart/terminal/journal/report の document・schema・transformer は無改変。`journal_text` 維持。
+- **既存データ**: マイグレーションしない（歴史データは XML・新規は JSON の混在を許容）。
+
+> 具体的な JSON フィールド名・要素タイプ名・pydantic 表現は [contracts/print-document.schema.md](./contracts/print-document.schema.md) で定義する。
+
+---
+
+## Dependencies & Prerequisites
+
+| 依存先 | 種類 | 理由 |
+|---|---|---|
+| stpos-backend #316 spec | 流用元 | 本仕様の派生元。スキーマ契約・例を再利用 |
+| Issue #139 | 要件 | スコープ（backend の形式と生成ロジックに限定）の確定根拠 |
+
+---
+
+## Success Criteria
+
+- **SC-001**: 取引確定時、新スキーマ準拠の `print_document` が生成され、スキーマ検証に **100% 適合**する
+- **SC-002**: 切替前後で同一取引のレシート内容（行・順序・文言）が**論理的に保たれる**（開発時は旧 XML 生成結果を基準に等価性を検証）
+- **SC-003**: 要求された全表現（位置・倍角等修飾・ロゴ・画像・バーコード・QR・行送り・カット・複数カラム）が JSON で表現可能であることが各要素テストで確認される
+- **SC-004**: 切替後、XML 生成・保存・配信経路が製品コードから**消えている**こと。journal/report が JSON を正しく扱い、歴史データ（XML）の読み出しがエラーにならないこと
+- **SC-005**: `journal_text` が回帰しないこと（移行前後で同一取引のプレーンテキストが一致）
+- **SC-006**: 既存の単体テスト・結合テストが**全件パス**する
+
+---
+
+## Out of Scope
+
+- **印字データを実機コマンドへ変換・描画する device-gateway 相当の処理**（OPOS/ESC-POS 等への変換、桁揃えの最終計算、実機描画）— 消費者（frontend/device）の責務
+- デバイス能力差の吸収（カッター有無・非対応シンボロジー・非対応修飾の degradation）
+- 非同期印字ジョブ実行・印字ジョブ冪等性（jobId）・状態/能力照会 API
+- 対象デバイスの文字セット（Shift-JIS 等）への変換・マップ不能文字の代替（UTF-8 のまま消費者へ渡す）
+- 既存ドキュメントの `receipt_text`(XML) → JSON データマイグレーション
+- カラム内スパン粒度の文字修飾（行＝text／カラム＝columns 単位までを対象）
+- 管理画面からのレシートレイアウト編集 UI
+
+---
+
+## 未解決事項（plan で確定）
+
+- 画像/ロゴ要素を実際の戦略で使うか（初期は cart sample で showcase。report/terminal は最小変更で JSON 化）。
+- 代替文字や倍角桁数換算は消費者責務のため本リポジトリでは規定しない（メタの `charsPerLine` のみ提供）。
+- 帳票（report）レシートの `print_document` 文書種別（`documentType`）の値（`receipt` か `report` か）。

--- a/specs/139-receipt-print-schema/tasks.md
+++ b/specs/139-receipt-print-schema/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: device-agnostic な印字データスキーマ（XML 撤去・JSON 化）
+
+**Branch**: `139-receipt-print-schema` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+凡例: `[P]` = 並行可能（依存なし） / 各タスクは英語コメント・型注釈を遵守。
+
+## Phase 1: commons（基盤）
+
+- [ ] **T001** `services/commons/src/kugel_common/receipt/print_document_model.py` を新規作成（Style/Column/各 Element/Metadata/PrintDocument）。`examples/builder-example.py` のモデル定義を流用し、`ImageElement`/`ImageSource` を追加。`PrintDocument.to_dict()`（`model_dump(by_alias=True, exclude_none=True)`）を提供。
+- [ ] **T002** `services/commons/src/kugel_common/receipt/receipt_data_model.py` を改修。`pydantic-xml` 依存を撤去。`Page`（`lines: list`）・`Line`（Element エイリアス）・`Constants` を維持。`PrintData`/`to_xml`/`Table`/`TableRow` を削除。
+- [ ] **T003** `services/commons/src/kugel_common/receipt/abstract_receipt_data.py` を改修。`make_receipt_text`(XML) を削除。`line_*` シムを Element 生成へ再実装。`build_print_document(model, elements)` と `render_journal_text(elements, width)` を追加。`make_receipt_data` が `ReceiptData(print_document, journal_text)` を返すよう変更。`ReceiptData` モデルの `receipt_text` を `print_document: dict` に置換。
+- [ ] **T004** `services/commons/src/kugel_common/models/documents/base_tranlog.py`: `receipt_text` を `print_document: Optional[dict[str, Any]] = None` に置換。
+- [ ] **T005** commons 検証: `pipenv run ruff check src/` + 既存 receipt 系 unit テスト。`render_journal_text` の出力が現行 `to_text` と一致することを確認。
+
+## Phase 2: cart（依存: Phase 1）
+
+- [ ] **T010** `services/cart/app/api/common/schemas.py`（`BaseTran`）: `receipt_text` → `print_document: Optional[dict] = None`。
+- [ ] **T011** `services/cart/app/api/common/schemas_transformer.py`: `receipt_text=...` 2 箇所を `print_document=...` へ。
+- [ ] **T012** `services/cart/app/models/repositories/cart_repository.py`: `cart.receipt_text = ""` を `cart.print_document = None` へ。
+- [ ] **T013** `services/cart/app/services/tran_service.py`: `tranlog.receipt_text`/`cart.receipt_text`/`tran.receipt_text`（3 ブロック）を `print_document` へ。`print_data` 変数名はそのままで `make_receipt_data` の戻り値 `.print_document` を使用。
+- [ ] **T014** cart テスト更新: `tests/log_maker.py`・`tests/unit/test_api_cart.py`・`test_api_tran.py`・`test_cart_repository.py` の `receipt_text` 参照を `print_document` へ。
+- [ ] **T015** cart 検証: `pipenv run pytest -m unit`。
+
+## Phase 3: terminal（依存: Phase 1）
+
+- [ ] **T020** `services/terminal/app/models/documents/open_close_log.py`・`cash_in_out_log.py`: `receipt_text` → `print_document`。
+- [ ] **T021** `services/terminal/app/services/terminal_service.py`: `*.receipt_text = receipt_data.receipt_text`（4 箇所）を `print_document` へ。
+- [ ] **T022** `services/terminal/app/api/common/schemas.py`・`schemas_transformer.py`・`api/v1/schemas.py`・`api/v1/terminal.py`: `receipt_text` → `print_document`。
+- [ ] **T023** terminal テスト更新: `tests/unit/test_api_terminals.py`・`test_receipt_data.py`・`test_terminal_service_lifecycle.py`・`test_terminal_service_logging.py`。
+- [ ] **T024** terminal 検証: `pipenv run pytest -m unit`。
+
+## Phase 4: journal（依存: Phase 1, 2, 3 のスキーマ整合）
+
+- [ ] **T030** `services/journal/app/models/documents/jornal_document.py`・`open_close_log.py`・`cash_in_out_log.py`: `receipt_text: str` → `print_document: Optional[dict] = None`。
+- [ ] **T031** `services/journal/app/services/log_service.py`: `receipt_text=tran.receipt_text` 等を `print_document` へ。
+- [ ] **T032** `services/journal/app/api/common/schemas.py`・`schemas_transformer.py`: `receipt_text`/`receiptText` → `print_document`/`printDocument`。
+- [ ] **T033** journal テスト更新: `tests/integration/conftest.py`・`tests/unit/test_api_journal.py`・`test_journal_service.py`・`test_log_service.py`・`test_repositories.py`。
+- [ ] **T034** journal 検証: `pipenv run pytest -m unit`。
+
+## Phase 5: report（依存: Phase 1）
+
+- [ ] **T040** report 各 document: `cash_in_out_log.py`・`open_close_log.py`・`sales_report_document.py`・`item_report_document.py`・`category_report_document.py`・`payment_report_document.py`・`promotion_report_document.py`: `receipt_text` → `print_document`。
+- [ ] **T041** `services/report/app/services/report_service.py`: `receipt_text`/`receiptText`（帳票→journal 連携、659-703 付近）を `print_document`/`printDocument` へ。帳票生成器の戻り値 `.print_document` を使用。
+- [ ] **T042** report 帳票生成器（`sales_report_maker.py`・`item_report_maker.py`・`payment_report_maker.py`・`category_report_maker.py`・`promotion_report_maker.py` と `*_receipt_data.py`）: `make_receipt_data` の戻り値参照を `print_document` へ。生成器本体はシムで不変。
+- [ ] **T043** `services/report/app/api/common/schemas.py`・`schemas_transformer.py`: `receipt_text` → `print_document`。
+- [ ] **T044** report テスト・補助更新: `tests/e2e/test_*`・`tests/log_maker.py`・`tests/unit/test_journal_integration.py`・`debug_receipt_generation.py`。
+- [ ] **T045** report 検証: `pipenv run pytest -m unit`。
+
+## Phase 6: 統合検証
+
+- [ ] **T050** 全サービス `ruff check`。
+- [ ] **T051** production コードに `receipt_text` / `to_xml` / `pydantic_xml` が残っていないことを確認（`grep -rn 'receipt_text\|to_xml\|pydantic_xml' services/*/app services/commons/src` がテスト以外で 0）。
+- [ ] **T052** 全サービス unit テスト パス（commons/cart/terminal/journal/report）。
+- [ ] **T053** 可能なら integration テスト（MongoDB 必要）。


### PR DESCRIPTION
Closes #139.

## Summary
Migrate the receipt print data from an **XML string** to a **device-agnostic JSON string**, keeping the existing `receipt_text` field (name and `str` type unchanged) — only the *content* changes. Also add per-element **R/J/RJ channel (station) routing**. The change is confined to `kugel_common`; cart/terminal/journal/report code, documents, schemas, transformers, the tranlog/pub-sub payload, and their tests are **untouched**.

## What changed
**`kugel_common` (only code change)**
- **New** `receipt/print_document_model.py` — the OPOS/printer-independent print-data schema: `PrintDocument`/`Metadata`/`Style`/`Column` + a `type`-discriminated element union (`text`, `columns` with left/mid(`startCol`)/right semantic columns, `ruledLine`, `feed`, `cut`, `barcode`, `qrcode`, `image`, `logo`). Serialized as camelCase JSON.
- `receipt/receipt_data_model.py` — drop `pydantic-xml`; keep `Page`/`Line`/`Constants` as the intermediate a strategy builds.
- `receipt/abstract_receipt_data.py` — remove the XML path (`PrintData.to_xml` / `make_receipt_text`). `make_receipt_data()` now sets `receipt_text = json.dumps(print_document)` and derives `journal_text` from the same elements (byte-equivalent to the old `to_text`). The `line_*` helpers are backward-compatible shims, so the 7 existing receipt generators produce the same content with **no code change**.

**R/J/RJ channel (station) routing**
- Each print element carries an internal `channel` (`R`/`J`/`RJ`, default `RJ`), excluded from the JSON. `build_print_document` emits R/RJ into `receipt_text`; `render_journal_text` emits J/RJ into `journal_text`. `line_*` gain a `channel` arg (default `RJ`). Adds routing unit tests.

**Docs / spec**
- `specs/139-receipt-print-schema/` — spec, plan, tasks, contract (`print-document.schema.md`), examples (`normal-sale.json` + a runnable `builder-example.py`), checklist. DeviceGW rendering is out of scope; the field stays `receipt_text`/`str`.
- `docs/{ja,en}/commons/common-function-spec.md` — replace the removed XML model section with the JSON `print_document` model.

## Scope decisions
- **Field name `receipt_text` and `str` type are kept** — only the string content moves XML → JSON. No new field, no schema/transformer/document changes in services.
- **Out of scope** (per #139): rendering JSON to device commands (device-gateway), async print jobs, idempotency, capability query — the consumer's responsibility. Rich expressiveness (logo / double-width / barcode / QR) is proven by the schema + examples, not injected into production receipts (so receipt content and `journal_text` do not regress).
- Historical XML data is not migrated; `receipt_text` stays `str`, so old XML and new JSON coexist (readers can detect by leading `{` vs `<`).

## Testing
Validated against the rebuilt images on the full Dapr stack (real MongoDB/Redis/RabbitMQ):
- **Unit**: 8/8 services pass (+ commons routing tests)
- **Integration**: 7/7 services pass (real replica-set MongoDB)
- **E2E**: 8/8 pass — per-service (account/master-data/terminal/journal/stock/report/cart) **and** the comprehensive cross-service suite (31 passed)
- A created tranlog confirms `receipt_text` is a `string` holding the JSON print document (no `print_document` field added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)