### PR TITLE
feat(receipt): add explicit width to mid column so align is well-defined (#143)

### DIFF
--- a/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
+++ b/services/commons/src/kugel_common/receipt/abstract_receipt_data.py
@@ -171,12 +171,37 @@ class AbstractReceiptData(ABC, Generic[T]):
             if start > cursor:
                 line += TextHelper.space(start - cursor)
                 cursor = start
-            line += column.value
-            cursor += wcwidth.wcswidth(column.value)
+            # A `mid` column with an explicit width defines a cell
+            # [startCol, startCol + width) that `align` operates within;
+            # otherwise the value is placed as-is at its start (legacy mid/left).
+            if column.slot == "mid" and column.width is not None:
+                cell = self._render_mid_cell(column.value, column.width, column.align)
+                line += cell
+                cursor += wcwidth.wcswidth(cell)
+            else:
+                line += column.value
+                cursor += wcwidth.wcswidth(column.value)
         if right_value is not None:
             pad = width - cursor - wcwidth.wcswidth(right_value)
             line += TextHelper.space(max(1, pad)) + right_value
         return line
+
+    @staticmethod
+    def _render_mid_cell(value: str, cell_width: int, align: Optional[str]) -> str:
+        """Render a `mid` column value inside its [startCol, startCol+width) cell.
+
+        ``align`` is honored within the cell: ``right`` left-pads with spaces,
+        ``center`` centers, ``left`` (default) right-pads. A value wider than the
+        cell overflows to the right with no padding on the overflow side."""
+        pad_total = max(0, cell_width - wcwidth.wcswidth(value))
+        if align == "right":
+            left_pad, right_pad = pad_total, 0
+        elif align == "center":
+            left_pad = pad_total // 2
+            right_pad = pad_total - left_pad
+        else:  # left / default
+            left_pad, right_pad = 0, pad_total
+        return TextHelper.space(left_pad) + value + TextHelper.space(right_pad)
 
     #
     # date/format helpers

--- a/services/commons/src/kugel_common/receipt/print_document_model.py
+++ b/services/commons/src/kugel_common/receipt/print_document_model.py
@@ -80,6 +80,11 @@ class Column(BaseModel):
     # Required only for the `mid` slot: fixed offset from the left (half-width
     # columns, 0-based, based on metadata.charsPerLine).
     start_col: Optional[int] = Field(None, alias="startCol")
+    # `mid` only: explicit cell width (half-width columns). With it the `mid`
+    # cell is [startCol, startCol + width) and `align` operates within that cell
+    # (right -> left-padded with spaces, center -> centered). `left`/`right`
+    # derive their cell from anchors and ignore `width`.
+    width: Optional[int] = Field(None, ge=0)
     # Default per slot: left/mid -> left, right -> right (resolved by consumer).
     align: Optional[Literal["left", "center", "right"]] = None
     style: Optional[Style] = None

--- a/services/commons/tests/unit/test_receipt_columns_mid_width.py
+++ b/services/commons/tests/unit/test_receipt_columns_mid_width.py
@@ -1,0 +1,167 @@
+# Copyright 2025 masa@kugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the `mid` column explicit-width / align rendering (#143).
+
+The `mid` cell is [startCol, startCol + width); `align` operates within it.
+`left`/`right` keep their anchor-based behavior. Production receipts only emit
+left+right pairs, so those stay byte-equivalent (covered elsewhere)."""
+import pytest
+import wcwidth
+
+from kugel_common.receipt.abstract_receipt_data import AbstractReceiptData
+from kugel_common.receipt.print_document_model import Column, ColumnsElement
+from kugel_common.receipt.receipt_data_model import Page
+
+
+def _disp_slice(text: str, start: int, end: int) -> str:
+    """Slice ``text`` by display column (wcwidth), not character index, so
+    assertions hold when wide (full-width) characters precede the region."""
+    out = ""
+    col = 0
+    for ch in text:
+        if start <= col < end:
+            out += ch
+        col += wcwidth.wcwidth(ch)
+    return out
+
+
+class _Strategy(AbstractReceiptData):
+    def make_receipt_header(self, model, page: Page):
+        pass
+
+    def make_receipt_body(self, model, page: Page):
+        pass
+
+    def make_receipt_footer(self, model, page: Page):
+        pass
+
+
+@pytest.fixture
+def strategy():
+    return _Strategy("default", 48)
+
+
+def _render(strategy, columns, width=48):
+    return strategy._render_columns_element(ColumnsElement(columns=columns), width)
+
+
+# ---- cell alignment (independent of wide-char positioning) ----
+
+
+def test_cell_align_right_left_pads_within_cell():
+    # value width 7 inside a width-10 cell -> 3 leading spaces, no trailing.
+    assert AbstractReceiptData._render_mid_cell("@108 x1", 10, "right") == "   @108 x1"
+
+
+def test_cell_align_left_is_default():
+    # "2点" display width 3 (1 + 2) inside a width-8 cell -> 5 trailing spaces.
+    assert AbstractReceiptData._render_mid_cell("2点", 8, None) == "2点     "
+    assert AbstractReceiptData._render_mid_cell("2点", 8, "left") == "2点     "
+
+
+def test_cell_align_center():
+    # value width 2 inside width-6 cell -> 2 left, 2 right.
+    assert AbstractReceiptData._render_mid_cell("ab", 6, "center") == "  ab  "
+    # odd remainder favors the right side (floor on the left).
+    assert AbstractReceiptData._render_mid_cell("ab", 7, "center") == "  ab   "
+
+
+def test_cell_value_wider_than_cell_overflows_with_no_padding():
+    assert AbstractReceiptData._render_mid_cell("ABCDEF", 3, "right") == "ABCDEF"
+    assert AbstractReceiptData._render_mid_cell("ABCDEF", 3, "left") == "ABCDEF"
+
+
+# ---- positioning within a full columns line (ASCII left so char==display col) ----
+
+
+def test_mid_cell_positioned_at_start_col(strategy):
+    line = _render(
+        strategy,
+        [
+            Column(slot="left", value="Tea"),  # width 3
+            Column(slot="mid", value="@1", start_col=10, width=6, align="right"),
+            Column(slot="right", value="108"),
+        ],
+    )
+    # cell [10, 16): "@1" right-justified -> 4 spaces then "@1".
+    assert line[10:16] == "    @1"
+
+
+def test_mid_without_width_keeps_legacy_behavior(strategy):
+    """A mid column with no width places the value at startCol (align ignored)."""
+    line = _render(
+        strategy,
+        [
+            Column(slot="left", value="ST"),
+            Column(slot="mid", value="2pt", start_col=10, align="right"),
+            Column(slot="right", value="258"),
+        ],
+    )
+    assert line[10:13] == "2pt"  # value sits exactly at startCol, no left padding
+
+
+def test_left_right_pair_unaffected(strategy):
+    """The common left+right pair path is unchanged by the mid-width addition."""
+    line = _render(strategy, [Column(slot="left", value="合計"), Column(slot="right", value="278")])
+    assert line.endswith("278")
+
+
+# ---- full-width (Japanese) character handling ----
+
+
+def test_cell_align_uses_display_width_for_japanese():
+    """Padding is computed from display width (wcwidth), so the rendered cell is
+    exactly ``width`` display columns wide regardless of full-width characters."""
+    # "商品" display width 4 in a width-10 cell -> 6-space pad.
+    assert AbstractReceiptData._render_mid_cell("商品", 10, "right") == "      商品"
+    assert AbstractReceiptData._render_mid_cell("商品", 10, "left") == "商品      "
+    assert AbstractReceiptData._render_mid_cell("商品", 10, "center") == "   商品   "
+    for align in ("right", "left", "center"):
+        cell = AbstractReceiptData._render_mid_cell("商品", 10, align)
+        assert wcwidth.wcswidth(cell) == 10
+
+
+def test_japanese_mid_cell_positioned_by_display_column():
+    """A mid cell with full-width content lands at the right display columns even
+    when the preceding left value itself contains wide characters."""
+    strategy = _Strategy("default", 48)
+    line = _render(
+        strategy,
+        [
+            Column(slot="left", value="お茶 500ml"),  # wide chars before the cell
+            Column(slot="mid", value="＠商品", start_col=14, width=10, align="right"),
+            Column(slot="right", value="108外"),
+        ],
+    )
+    # Cell occupies display columns [14, 24): value width 6 -> 4 leading spaces.
+    cell = _disp_slice(line, 14, 24)
+    assert cell == "    ＠商品"
+    assert wcwidth.wcswidth(cell) == 10
+    assert wcwidth.wcswidth(line) == 48
+
+
+def test_mid_width_serialized_in_print_document():
+    """`width` is emitted (camelCase) in the print document when set on a mid column."""
+    element = ColumnsElement(
+        columns=[
+            Column(slot="left", value="お茶"),
+            Column(slot="mid", value="@108", start_col=14, width=10, align="right"),
+            Column(slot="right", value="108外"),
+        ]
+    )
+    dumped = element.model_dump(by_alias=True, exclude_none=True)
+    mid = next(c for c in dumped["columns"] if c["slot"] == "mid")
+    assert mid["width"] == 10
+    assert mid["startCol"] == 14
+    assert mid["align"] == "right"

--- a/services/commons/tests/unit/test_receipt_columns_mid_width.py
+++ b/services/commons/tests/unit/test_receipt_columns_mid_width.py
@@ -111,6 +111,24 @@ def test_mid_without_width_keeps_legacy_behavior(strategy):
     assert line[10:13] == "2pt"  # value sits exactly at startCol, no left padding
 
 
+def test_mid_width_colliding_with_right_keeps_min_one_space(strategy):
+    """When a wide mid cell would overrun the right column, the renderer still
+    emits both values with at least one separating space (no truncation, no
+    crash) — truncation on collision is the consumer's responsibility."""
+    line = _render(
+        strategy,
+        [
+            Column(slot="left", value="ST"),
+            # cell [10, 45): cursor ends at 45, leaving no room before "right".
+            Column(slot="mid", value="MID", start_col=10, width=35, align="left"),
+            Column(slot="right", value="99999"),
+        ],
+        width=48,
+    )
+    assert "MID" in line
+    assert line.endswith(" 99999")  # min one space guaranteed before the right value
+
+
 def test_left_right_pair_unaffected(strategy):
     """The common left+right pair path is unchanged by the mid-width addition."""
     line = _render(strategy, [Column(slot="left", value="合計"), Column(slot="right", value="278")])

--- a/specs/139-receipt-print-schema/contracts/print-document.schema.md
+++ b/specs/139-receipt-print-schema/contracts/print-document.schema.md
@@ -65,11 +65,23 @@
 | `slot` | `left`\|`mid`\|`right` | — | `left`=左端起点 / `mid`=`startCol` 起点 / `right`=右端終端 |
 | `value` | string | — | カラムの文字列 |
 | `startCol` | int | — | **`mid` のみ必須**。左からの固定オフセット（半角換算・0始まり、`charsPerLine` 基準） |
-| `align` | `left`\|`center`\|`right` | `left`（`right` slot は `right`） | カラム内の寄せ |
+| `width` | int | — | **`mid` のみ**。セル幅（半角換算）。`mid` のセルは `[startCol, startCol + width)` となり、`align` はこのセル内で適用される。`left`/`right` はアンカーからセルを導出するため `width` を無視する |
+| `align` | `left`\|`center`\|`right` | `left`（`right` slot は `right`） | カラム内（セル内）の寄せ |
 | `style` | Style | （なし） | **カラム単位**の文字修飾 |
 
+**セル境界の導出**
+- `left`: col 0 起点。セルは次のアンカー（`mid` の `startCol` または `right`）まで。
+- `mid`: `startCol` 起点。`width` があればセルは `[startCol, startCol + width)`。`width` 無しの場合はセル未定義（`value` を `startCol` に置くのみ＝従来動作、`align` は意味を持たない）。
+- `right`: 右端終端。セル幅 ＝ 内容幅（`value` 幅）。
+
+**`align`（セル内の寄せ）** — `mid` で `width` を指定した場合に well-defined となる。
+- `align="left"`（既定）: `value` を `startCol` に置く（セル右側を空白で埋める）。
+- `align="right"`: セル内で右寄せ。`startCol` から `value` 開始位置まで左側を空白で埋める。
+- `align="center"`: セル内で中央寄せ。
+- `value` がセル幅より広い場合は右へはみ出す（はみ出し側のパディングなし）。
+
 **レイアウト規則（消費者が実施）**
-- `left` は col 0 から、`mid` は `startCol` から右へ、`right` は右端へ寄せる。
+- `left` は col 0 から、`mid` は `startCol` から右へ、`right` は右端へ寄せる。`mid` の `width` 指定時は上記 `align` をセル内で適用する。
 - 桁衝突時は `mid` の開始位置で `left` を切詰める（同様に `right` の開始位置で `mid` を切詰める）。
 - 倍角カラムは 2 セル換算で配置する。
 - `charsPerLine`（設計基準）と実機幅が異なる場合、消費者が `charsPerLine` を基準に実幅へ適合させる。

--- a/specs/139-receipt-print-schema/examples/builder-example.py
+++ b/specs/139-receipt-print-schema/examples/builder-example.py
@@ -21,7 +21,8 @@ Level 1 のポイント:
   - 複数カラム行は columns 要素（left/mid/right）で**意味のまま**出力する
     （空白を焼き込まない）。桁揃えは DeviceGW が metadata.charsPerLine を
     基準に実施する（ADR-0003）。
-  - mid は startCol（左からの固定オフセット）。桁衝突時は mid.startCol で left を切詰め。
+  - mid は startCol（左からの固定オフセット）。width 指定時はセル [startCol, startCol+width)
+    内で align を適用（right=左を空白埋め）。桁衝突時は mid.startCol で left を切詰め。
   - style は text=行単位 / columns=カラム単位。
 
 構成:
@@ -66,6 +67,7 @@ class Column(BaseModel):
     slot: Literal["left", "mid", "right"]
     value: str
     start_col: Optional[int] = Field(None, alias="startCol")  # mid のみ必須
+    width: Optional[int] = Field(None, ge=0)  # mid のみ: セル [startCol, startCol+width)
     align: Optional[Literal["left", "center", "right"]] = None  # 既定: left/mid=left, right=right
     style: Optional[Style] = None
 
@@ -157,8 +159,8 @@ def L(value, style=None):                     # left カラム
     return Column(slot="left", value=value, style=style)
 
 
-def M(value, start_col, style=None):          # mid カラム（開始位置指定）
-    return Column(slot="mid", value=value, start_col=start_col, style=style)
+def M(value, start_col, width=None, align=None, style=None):  # mid カラム（開始位置＋セル幅）
+    return Column(slot="mid", value=value, start_col=start_col, width=width, align=align, style=style)
 
 
 def R(value, style=None):                     # right カラム
@@ -219,7 +221,7 @@ def build_print_document_example() -> PrintDocument:
     # ===== ボディ =====
     b.rule()
     b.columns(L("おにぎり(鮭)"), R("150外"))
-    b.columns(L("お茶 500ml"), M("@108 x1", start_col=14), R("108外"))
+    b.columns(L("お茶 500ml"), M("@108 x1", start_col=14, width=10, align="right"), R("108外"))
     b.rule()
     b.columns(L("小計"), M("2点", start_col=10), R("258"))
     b.columns(L("  消費税(外税8%)"), R("20"))

--- a/specs/139-receipt-print-schema/examples/normal-sale.json
+++ b/specs/139-receipt-print-schema/examples/normal-sale.json
@@ -72,7 +72,9 @@
         {
           "slot": "mid",
           "value": "@108 x1",
-          "startCol": 14
+          "startCol": 14,
+          "width": 10,
+          "align": "right"
         },
         {
           "slot": "right",


### PR DESCRIPTION
## Summary

Follow-up to #139. The `columns` schema gave a `mid` column a `startCol` but **no width**, so the region that `align` should operate within was undefined — `align` on a `mid` column could not be realized. This adds an explicit **`width`** field so a `mid` cell is `[startCol, startCol + width)` and `align` is well-defined inside it.

Closes #143.

## Changes

- **`print_document_model.py`**: add `Column.width: Optional[int]` (`ge=0`, serialized camelCase as semantic info; no baked spaces in the JSON).
- **`abstract_receipt_data.py`**: in plain-text journal rendering, honor `mid` `width` + `align` via a new `_render_mid_cell` helper:
  - `align="right"` → right-justify inside the cell (left padded with spaces)
  - `align="center"` → centered (odd remainder favors the right)
  - `align="left"` (default) → value at `startCol`, right padded
  - value wider than the cell overflows right with no extra padding
  - padding is computed from **display width (`wcwidth`)**, so full-width/Japanese values land at the correct columns
  - `mid` without `width` keeps legacy behavior (value at `startCol`, `align` ignored)
- **`contracts/print-document.schema.md`**: document the `width` field, `left`/`mid`/`right` cell derivation, and `align`-within-cell semantics.
- **examples**: `normal-sale.json` and `builder-example.py` show a `mid` column with `width: 10, align: "right"` (the issue's `お茶 500ml` example). Builder output is byte-identical to `normal-sale.json`.
- **tests** (`test_receipt_columns_mid_width.py`): cell alignment (right/left/center/overflow), display-column positioning, full-width (Japanese) handling, legacy no-width path, left+right pair unchanged, and JSON serialization.

## Non-regression

Production receipt generators only use `left` + `right` (from `line_split`); none use `mid`. So `journal_text` for production receipts stays byte-equivalent — this change only affects receipts that opt into `mid` columns (examples/tests today).

## Verification

- commons unit suite: **373 passed** (including 10 new mid-width tests).
- `builder-example.py` output `diff` against `normal-sale.json`: **MATCH**.
- Full-width handling verified: rendered `mid` cells are exactly `width` display columns wide and land at the expected `startCol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)