### PR TITLE
fix(tests): compute business-date expectations in app timezone (#150)

### DIFF
--- a/services/cart/tests/integration/conftest.py
+++ b/services/cart/tests/integration/conftest.py
@@ -17,6 +17,7 @@ MongoDB needed:
 import os
 import re
 from datetime import datetime, timedelta, timezone  # noqa: F401
+from kugel_common.utils.misc import get_app_time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -240,7 +241,7 @@ def mock_outbound(admin_token, mock_grpc_item_lookup):
                 "description": "Test Terminal",
                 "functionMode": "OpenTerminal",
                 "status": "Opened",
-                "businessDate": datetime.now().strftime("%Y%m%d"),
+                "businessDate": get_app_time().strftime("%Y%m%d"),
                 "openCounter": 1,
                 "businessCounter": 1,
                 "initialAmount": 50000.0,
@@ -263,7 +264,7 @@ def mock_outbound(admin_token, mock_grpc_item_lookup):
                 "storeCode": store_code,
                 "storeName": "Test Store",
                 "status": "Idle",
-                "businessDate": datetime.now().strftime("%Y%m%d"),
+                "businessDate": get_app_time().strftime("%Y%m%d"),
                 "tags": [],
             },
         }))

--- a/services/cart/tests/integration/test_setup_data.py
+++ b/services/cart/tests/integration/test_setup_data.py
@@ -7,6 +7,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 import os
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 import pytest
 import pytest_asyncio
@@ -40,7 +41,7 @@ async def test_setup_data(setup_db: AsyncIOMotorDatabase):
     assert setup_db is not None
     print("database name: ", setup_db.name)
 
-    business_date_str = datetime.now().strftime("%Y%m%d")
+    business_date_str = get_app_time().strftime("%Y%m%d")
 
     terminal_info = _make_terminal_info(
         tenant_id=os.environ.get("TENANT_ID"),

--- a/services/journal/tests/e2e/test_journal.py
+++ b/services/journal/tests/e2e/test_journal.py
@@ -8,6 +8,7 @@ Sequence:
 """
 import os
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 import pytest
 from fastapi import status
@@ -34,8 +35,8 @@ async def test_post_and_get_journals(http_client, admin_header):
     tenant_id = os.environ.get("TENANT_ID")
     store_code = "5678"
     terminal_no = 9
-    business_date = datetime.now().strftime("%Y%m%d")
-    transaction_no = int(datetime.now().strftime("%H%M%S"))
+    business_date = get_app_time().strftime("%Y%m%d")
+    transaction_no = int(get_app_time().strftime("%H%M%S"))
 
     response = await http_client.post(
         f"/api/v1/tenants/{tenant_id}/stores/{store_code}/terminals/{terminal_no}/journals",
@@ -82,7 +83,7 @@ async def test_post_and_get_journals(http_client, admin_header):
 async def test_get_journals_with_filters(http_client, admin_header):
     """GET /journals with various filter params returns successfully."""
     tenant_id = os.environ.get("TENANT_ID")
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
 
     response = await http_client.get(
         f"/api/v1/tenants/{tenant_id}/stores/5678/journals"

--- a/services/journal/tests/integration/conftest.py
+++ b/services/journal/tests/integration/conftest.py
@@ -34,7 +34,7 @@ async def _setup_journal_db(set_env_vars):
     from app.database import database_setup
     from app.models.documents.jornal_document import JournalDocument
     from app.models.repositories.journal_repository import JournalRepository
-    from kugel_common.utils.misc import get_app_time_str
+    from kugel_common.utils.misc import get_app_time, get_app_time_str
 
     db_helper.MONGODB_URI = os.environ.get("MONGODB_URI")
     db_client = await db_helper.get_client_async()
@@ -51,7 +51,7 @@ async def _setup_journal_db(set_env_vars):
     journal_repo = JournalRepository(db, tenant_id)
     store_code = os.environ.get("STORE_CODE")
     terminal_no = int(os.environ.get("TERMINAL_NO"))
-    business_date_str = datetime.now().strftime("%Y%m%d")
+    business_date_str = get_app_time().strftime("%Y%m%d")
 
     for seq, recipt_no, with_amount in [(122, 788, False), (123, 789, True)]:
         kwargs = dict(

--- a/services/report/tests/conftest.py
+++ b/services/report/tests/conftest.py
@@ -20,6 +20,7 @@ os.environ.setdefault("TERMINAL_ID", f"{os.environ.get('TENANT_ID', 'T9999')}-56
 import pytest_asyncio
 from httpx import AsyncClient, Client
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 from dotenv import load_dotenv
 import locale
 from unittest.mock import patch
@@ -101,7 +102,7 @@ def set_env_vars():
     os.environ["STORE_CODE"] = "5678"
     os.environ["TERMINAL_NO"] = "5555"
     os.environ["TERMINAL_ID"] = f"{tenant_id}-5678-5555"
-    os.environ["BUSINESS_DATE"] = datetime.now().strftime("%Y%m%d")
+    os.environ["BUSINESS_DATE"] = get_app_time().strftime("%Y%m%d")
 
     from kugel_common.database import database as db_helper
 

--- a/services/report/tests/e2e/test_category_report.py
+++ b/services/report/tests/e2e/test_category_report.py
@@ -17,6 +17,7 @@ import asyncio
 from fastapi import status
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 
 def check_category_report_data(report_data: dict):
@@ -83,7 +84,7 @@ async def test_category_report_operations(http_client):
     tenant_id: str = os.environ.get("TENANT_ID")
     store_code: str = os.environ.get("STORE_CODE")
     terminal_no: int = int(os.environ.get("TERMINAL_NO"))
-    business_date: str = datetime.now().strftime("%Y%m%d")
+    business_date: str = get_app_time().strftime("%Y%m%d")
     
     # get token from auth service
     login_data = {
@@ -298,7 +299,7 @@ async def test_category_report_format_verification(http_client):
     """
     tenant_id = os.getenv("TENANT_ID")
     store_code = os.getenv("STORE_CODE")
-    business_date = os.getenv("BUSINESS_DATE", datetime.now().strftime("%Y%m%d"))
+    business_date = os.getenv("BUSINESS_DATE", get_app_time().strftime("%Y%m%d"))
     
     # Get token for authenticated requests
     login_data = {

--- a/services/report/tests/e2e/test_item_report.py
+++ b/services/report/tests/e2e/test_item_report.py
@@ -17,6 +17,7 @@ import asyncio
 from fastapi import status
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 
 def check_item_report_data(report_data: dict):
@@ -119,7 +120,7 @@ async def test_item_report_operations(http_client):
     tenant_id: str = os.environ.get("TENANT_ID")
     store_code: str = os.environ.get("STORE_CODE")
     terminal_no: int = int(os.environ.get("TERMINAL_NO"))
-    business_date: str = datetime.now().strftime("%Y%m%d")
+    business_date: str = get_app_time().strftime("%Y%m%d")
     
     # get token from auth service
     login_data = {

--- a/services/report/tests/e2e/test_journal_integration_simple.py
+++ b/services/report/tests/e2e/test_journal_integration_simple.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 
 @pytest.mark.asyncio
@@ -17,7 +18,7 @@ async def test_api_key_journal_integration():
     store_code = os.environ.get("STORE_CODE", "S001")
     terminal_no = int(os.environ.get("TERMINAL_NO", "1"))
     terminal_id = os.environ.get("TERMINAL_ID", f"{tenant_id}_{store_code}_{terminal_no}")
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
     base_url_report = os.environ.get("BASE_URL_REPORT", "http://localhost:8004")
     base_url_terminal = os.environ.get("BASE_URL_TERMINAL", "http://localhost:8001")
     token_url = os.environ.get("TOKEN_URL", "http://localhost:8000/api/v1/auth/token")

--- a/services/report/tests/e2e/test_payment_report_all.py
+++ b/services/report/tests/e2e/test_payment_report_all.py
@@ -9,6 +9,7 @@ from fastapi import status
 import os
 from httpx import AsyncClient
 from datetime import datetime, timedelta
+from kugel_common.utils.misc import get_app_time
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
 # db_helper imported locally in functions to avoid connection reuse
@@ -490,7 +491,7 @@ async def test_payment_report_via_api(http_client):
     
     tenant_id = os.environ.get("TENANT_ID")
     store_code = os.environ.get("STORE_CODE")
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
     
     # Get authentication token
     login_data = {
@@ -646,7 +647,7 @@ async def test_payment_report_error_handling(http_client):
         params={
             "report_scope": "daily",
             "report_type": "payment",
-            "business_date": datetime.now().strftime("%Y%m%d"),
+            "business_date": get_app_time().strftime("%Y%m%d"),
             "open_counter": 1
         }
     )

--- a/services/report/tests/e2e/test_promotion_report.py
+++ b/services/report/tests/e2e/test_promotion_report.py
@@ -16,6 +16,7 @@ import os
 from fastapi import status
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 
 def check_promotion_report_data(report_data: dict):
@@ -85,7 +86,7 @@ async def test_promotion_report_operations(http_client):
     tenant_id: str = os.environ.get("TENANT_ID")
     store_code: str = os.environ.get("STORE_CODE")
     terminal_no: int = int(os.environ.get("TERMINAL_NO"))
-    business_date: str = datetime.now().strftime("%Y%m%d")
+    business_date: str = get_app_time().strftime("%Y%m%d")
 
     # Get token from auth service
     login_data = {

--- a/services/report/tests/e2e/test_report.py
+++ b/services/report/tests/e2e/test_report.py
@@ -3,6 +3,7 @@ import pytest, os, asyncio
 from fastapi import status
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 from tests.check_report_data import check_report_data
 
@@ -13,7 +14,7 @@ async def test_report_operations(http_client):
     tenant_id: str = os.environ.get("TENANT_ID")
     store_code: str = os.environ.get("STORE_CODE")
     terminal_no: int = int(os.environ.get("TERMINAL_NO"))
-    business_date: str = datetime.now().strftime("%Y%m%d")
+    business_date: str = get_app_time().strftime("%Y%m%d")
 
     # get token from auth service
     login_data = {
@@ -211,7 +212,7 @@ async def test_flush_backward_compatibility(http_client):
     store_code = os.getenv("STORE_CODE")
     terminal_no = int(os.getenv("TERMINAL_NO"))
     terminal_id = os.getenv("TERMINAL_ID", f"{tenant_id}-{store_code}-{terminal_no}")
-    business_date = os.getenv("BUSINESS_DATE", datetime.now().strftime("%Y%m%d"))
+    business_date = os.getenv("BUSINESS_DATE", get_app_time().strftime("%Y%m%d"))
 
     # Get token for authenticated requests
     login_data = {

--- a/services/report/tests/e2e/test_terminal_id_parsing.py
+++ b/services/report/tests/e2e/test_terminal_id_parsing.py
@@ -13,7 +13,7 @@ from httpx import AsyncClient
 from datetime import datetime
 from unittest.mock import patch
 from tests.log_maker import make_tran_log
-from kugel_common.utils.misc import get_app_time_str
+from kugel_common.utils.misc import get_app_time, get_app_time_str
 
 
 @pytest.mark.asyncio()
@@ -39,7 +39,7 @@ async def test_terminal_id_parsing_with_api_key(http_client):
     store_code = os.environ.get("STORE_CODE")
     terminal_no = int(os.environ.get("TERMINAL_NO"))
     terminal_id = os.environ.get("TERMINAL_ID")  # Format: T9999-5678-5555
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
 
     # Get JWT token to retrieve API key
     login_data = {
@@ -193,7 +193,7 @@ async def test_terminal_id_filtering_with_multi_terminal_data(http_client, clean
     terminal_no_2 = 5556  # Additional terminal for filtering test
     terminal_id_1 = f"{tenant_id}-{store_code}-{terminal_no_1}"
     terminal_id_2 = f"{tenant_id}-{store_code}-{terminal_no_2}"
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
 
     # Get JWT token
     login_data = {

--- a/services/report/tests/integration/conftest.py
+++ b/services/report/tests/integration/conftest.py
@@ -12,6 +12,7 @@ to apply.
 """
 import os
 from datetime import datetime, timedelta, timezone
+from kugel_common.utils.misc import get_app_time
 
 import httpx
 import jwt
@@ -34,7 +35,7 @@ def set_env_vars():
     os.environ.setdefault("STORE_CODE", "5678")
     os.environ.setdefault("TERMINAL_NO", "5555")
     os.environ.setdefault("TERMINAL_ID", f"{tenant_id}-5678-5555")
-    os.environ.setdefault("BUSINESS_DATE", datetime.now().strftime("%Y%m%d"))
+    os.environ.setdefault("BUSINESS_DATE", get_app_time().strftime("%Y%m%d"))
 
     from kugel_common.database import database as db_helper
     mongodb_uri = os.environ.get("MONGODB_URI") or "mongodb://localhost:27017/"
@@ -75,7 +76,7 @@ def mock_outbound():
                 "tenantId": tenant_id, "storeCode": "5678",
                 "terminalNo": 5555, "description": "Test",
                 "functionMode": "Sales", "status": "Opened",
-                "businessDate": datetime.now().strftime("%Y%m%d"),
+                "businessDate": get_app_time().strftime("%Y%m%d"),
                 "openCounter": 1, "businessCounter": 1,
                 "initialAmount": 0.0, "physicalAmount": None,
                 "staff": {"staffId": "S001", "staffName": "Staff", "staffPin": "1234"},

--- a/services/report/tests/integration/test_endpoints.py
+++ b/services/report/tests/integration/test_endpoints.py
@@ -18,6 +18,7 @@ sales-report regression tests:
 """
 import os
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 import pytest
 from fastapi import status
@@ -97,7 +98,7 @@ async def test_get_store_reports_empty(http_client, admin_header):
     """GET /reports returns successfully (empty/zero data) for a fresh store
     with no transactions."""
     tenant_id = os.environ.get("TENANT_ID")
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
 
     response = await http_client.get(
         f"/api/v1/tenants/{tenant_id}/stores/5678/reports",
@@ -115,7 +116,7 @@ async def test_get_store_reports_empty(http_client, admin_header):
 async def test_get_terminal_reports_empty(http_client, admin_header):
     """GET .../terminals/{tn}/reports — same as above but at terminal scope."""
     tenant_id = os.environ.get("TENANT_ID")
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
 
     response = await http_client.get(
         f"/api/v1/tenants/{tenant_id}/stores/5678/terminals/9/reports",

--- a/services/stock/tests/conftest.py
+++ b/services/stock/tests/conftest.py
@@ -20,6 +20,7 @@ os.environ.setdefault("TERMINAL_ID", f"{os.environ.get('TENANT_ID', 'T9999')}-56
 import pytest_asyncio
 from httpx import AsyncClient
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 from dotenv import load_dotenv
 
 
@@ -64,7 +65,7 @@ def set_env_vars():
     os.environ["STORE_CODE"] = "5678"
     os.environ["TERMINAL_NO"] = "5555"
     os.environ["TERMINAL_ID"] = f"{tenant_id}-5678-5555"
-    os.environ["BUSINESS_DATE"] = datetime.now().strftime("%Y%m%d")
+    os.environ["BUSINESS_DATE"] = get_app_time().strftime("%Y%m%d")
 
     # Set alert cooldown to 0 for testing
     os.environ["ALERT_COOLDOWN_SECONDS"] = "0"

--- a/services/terminal/tests/integration/test_terminal_lifecycle.py
+++ b/services/terminal/tests/integration/test_terminal_lifecycle.py
@@ -25,6 +25,7 @@ to the same conftest's localhost:3500 catch-all.
 """
 import os
 from datetime import datetime
+from kugel_common.utils.misc import get_app_time
 
 import pytest
 from fastapi import status
@@ -157,7 +158,7 @@ async def test_open(http_client, admin_header, mock_outbound_services):
     terminal_id, _ = await _create_terminal(http_client, admin_header)
     await _signin(http_client, admin_header, terminal_id)
     response = await _open(http_client, admin_header, terminal_id)
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = get_app_time().strftime("%Y%m%d")
     assert response.json()["data"]["businessDate"] == business_date
     assert response.headers.get("x-new-token"), "open should issue X-New-Token"
 

--- a/tests/e2e/test_data_consistency.py
+++ b/tests/e2e/test_data_consistency.py
@@ -14,9 +14,17 @@ every service for the same transaction in one place.
 import os
 import uuid
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import httpx
 import pytest
+
+
+def _app_business_date() -> str:
+    """Business date in the backend's app timezone. Services compute it via
+    settings.TIMEZONE (default Asia/Tokyo), not host-local time, so a UTC
+    host must not use datetime.now() here (#150)."""
+    return datetime.now(ZoneInfo(os.environ.get("TIMEZONE", "Asia/Tokyo"))).strftime("%Y%m%d")
 
 
 def _client(url_env: str) -> httpx.Client:
@@ -169,7 +177,7 @@ async def test_bill_propagates_to_journal_report_stock(wait_for):
         assert resp.status_code == 200, resp.text
         transaction_no = resp.json()["data"]["transactionNo"]
 
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = _app_business_date()
 
     # Wait for fan-out: poll journal until the transaction is present.
     # Once journal sees it, report and stock have typically caught up

--- a/tests/e2e/test_pos_full_journey.py
+++ b/tests/e2e/test_pos_full_journey.py
@@ -20,9 +20,17 @@ Uses a fresh tenant per run so reruns don't pollute existing state.
 import os
 import uuid
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import httpx
 import pytest
+
+
+def _app_business_date() -> str:
+    """Business date in the backend's app timezone. Services compute it via
+    settings.TIMEZONE (default Asia/Tokyo), not host-local time, so a UTC
+    host must not use datetime.now() here (#150)."""
+    return datetime.now(ZoneInfo(os.environ.get("TIMEZONE", "Asia/Tokyo"))).strftime("%Y%m%d")
 
 
 def _new_tenant_id() -> str:
@@ -213,7 +221,7 @@ async def test_pos_full_journey(wait_for):
     # 8. Wait for Dapr pub/sub fan-out (cart -> report / journal / stock).
     # Poll journal until the transaction surfaces; cuts the steady-state
     # wait when fan-out is fast and surfaces a real timeout if it hangs.
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = _app_business_date()
 
     def _journal_has_transaction() -> bool:
         with _client("URL_JOURNAL") as c:

--- a/tests/e2e/test_pubsub_idempotency.py
+++ b/tests/e2e/test_pubsub_idempotency.py
@@ -11,9 +11,17 @@ entries. Here we cover the auth-boundary / shape contracts directly.
 import os
 import uuid
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import httpx
 import pytest
+
+
+def _app_business_date() -> str:
+    """Business date in the backend's app timezone. Services compute it via
+    settings.TIMEZONE (default Asia/Tokyo), not host-local time, so a UTC
+    host must not use datetime.now() here (#150)."""
+    return datetime.now(ZoneInfo(os.environ.get("TIMEZONE", "Asia/Tokyo"))).strftime("%Y%m%d")
 
 
 def _client(url_env: str) -> httpx.Client:
@@ -62,7 +70,7 @@ def test_dapr_subscriber_drops_missing_event_id(url_env, path):
         "terminal_no": 1,
         "transaction_no": 1,
         "transaction_type": 101,
-        "business_date": datetime.now().strftime("%Y%m%d"),
+        "business_date": _app_business_date(),
         "open_counter": 1,
         "business_counter": 1,
         "generate_date_time": datetime.now().isoformat(),

--- a/tests/e2e/test_void_return_journey.py
+++ b/tests/e2e/test_void_return_journey.py
@@ -8,9 +8,17 @@ restored, report unchanged-net).
 import os
 import uuid
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import httpx
 import pytest
+
+
+def _app_business_date() -> str:
+    """Business date in the backend's app timezone. Services compute it via
+    settings.TIMEZONE (default Asia/Tokyo), not host-local time, so a UTC
+    host must not use datetime.now() here (#150)."""
+    return datetime.now(ZoneInfo(os.environ.get("TIMEZONE", "Asia/Tokyo"))).strftime("%Y%m%d")
 
 
 def _client(url_env: str) -> httpx.Client:
@@ -154,7 +162,7 @@ async def test_bill_then_void_propagates(wait_for):
     transaction_no, amount = _bill_cart(api_key, terminal_id, item_code, quantity=2)
     assert amount > 0
 
-    business_date = datetime.now().strftime("%Y%m%d")
+    business_date = _app_business_date()
 
     def _journal_types() -> list[int]:
         with _client("URL_JOURNAL") as c:


### PR DESCRIPTION
Closes #150.

## Problem

29 of the 31 `datetime.now().strftime(...)` occurrences in test code built business dates with **host-local time**, while the services compute them via `get_app_time()` using `settings.TIMEZONE` (default `Asia/Tokyo`). On a UTC host the two dates differ every day between 15:00 and 24:00 UTC, so date-keyed assertions and seed data fail deterministically in that window (`test_open` was the first symptom, caught during #149 validation).

## Fix

- **Service-level tests** (integration/e2e tests + conftests, 16 files): replace `datetime.now().strftime(...)` with `get_app_time().strftime(...)` from `kugel_common`. Files that defer kugel_common imports into fixtures (journal integration conftest) follow that existing pattern.
- **Repo-root `tests/e2e`** (4 files, own venv without kugel_common): add a per-file `_app_business_date()` helper using stdlib `zoneinfo` with the `TIMEZONE` env var (default `Asia/Tokyo`), keeping these tests dependency-free and self-contained.

## Deliberately out of scope

`services/stock/tests/unit/test_snapshot_scheduler_unit.py` keeps `datetime.now()`: the **app itself** generates snapshot lock keys with host-local time (`multi_tenant_snapshot_scheduler.py:144`), and test and app run in the same process, so they are always consistent. Changing only the test would break it. Whether the app should switch to `get_app_time()` for lock keys is a separate (behavioral) question.

## Verification

All runs executed at 22:00–23:00 UTC — **inside the failure window**, so the old code demonstrably fails and the new code demonstrably passes under the same conditions:

- Unit: 8/8 suites pass
- Integration: 7/7 suites pass (terminal's `test_open` included)
- E2E: 8/8 suites pass (7 services + cross-service `tests/e2e`), after rebuilding service images — an initial e2e run against stale pre-#139/#149 images failed on missing routes (404s), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)