### PR TITLE
chore(deps): resolve tests/e2e Dependabot alerts and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot configuration.
+#
+# Security alerts are raised for every Pipfile.lock in the repository, but
+# without this file no update PRs are opened, so each advisory has to be
+# resolved by hand. Listing all nine pipenv projects keeps the service locks,
+# the shared commons lock and the cross-service e2e harness lock in step.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/services/account"
+      - "/services/cart"
+      - "/services/commons"
+      - "/services/journal"
+      - "/services/master-data"
+      - "/services/report"
+      - "/services/stock"
+      - "/services/terminal"
+      - "/tests/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # One PR per project per week for routine bumps; security advisories
+      # still get their own dedicated PRs.
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/tests/e2e/Pipfile.lock
+++ b/tests/e2e/Pipfile.lock
@@ -59,20 +59,20 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15",
+                "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.19"
         },
         "pyjwt": {
             "hashes": [
-                "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c",
-                "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"
+                "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423",
+                "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.12.1"
+            "version": "==2.13.0"
         },
         "python-dotenv": {
             "hashes": [


### PR DESCRIPTION
## Summary

Closes the six Dependabot alerts that are genuinely outstanding, and adds the `.github/dependabot.yml` the repository never had.

### 1. `tests/e2e/Pipfile.lock` — 6 alerts

| Alert | Severity | Package | Change | CVE |
|---|---|---|---|---|
| #62 | High | pyjwt | 2.12.1 → 2.13.0 | CVE-2026-48526 public-key JWK accepted as HMAC secret |
| #103 | Medium | pyjwt | ″ | CVE-2026-48522 PyJWKClient missing scheme allowlist (SSRF) |
| #58 | Medium | pyjwt | ″ | CVE-2026-48525 unbounded Base64URL decode in detached JWS (DoS) |
| #56 | Medium | pyjwt | ″ | CVE-2026-48523 algorithm allow-list bypass via PyJWK/PyJWKClient |
| #101 | Low | pyjwt | ″ | CVE-2026-48524 unbounded JWKS requests via attacker-controlled `kid` |
| #30 | Medium | idna | 3.13 → 3.19 | CVE-2026-45409 `idna.encode()` bypass of the CVE-2024-3651 fix |

Real-world exposure was low: `tests/e2e` is a test harness that never ships, and its only pyjwt use is `jwt.encode` for forged test tokens (`test_auth_boundary.py:66`) — `PyJWK` / `PyJWKClient`, the entry point for four of the five advisories, is never touched. The fix is a lock bump, so it is worth taking regardless.

**Only the two lock entries change.** `pipenv update` initially rewrote the `Pipfile` (`pyjwt = ">=2.0.0"` → `"*"`, plus a spurious direct `idna` entry) and relocked unrelated packages including pytest 9.0.3 → 9.1.1 and pytest-asyncio 1.3.0 → 1.4.0. That was reverted — an unrequested pytest-asyncio minor bump could shift event-loop behaviour in the e2e suite, which is not something this PR should be smuggling in.

### 2. `.github/dependabot.yml` — new

The repository had no `.github/` directory at all. Alerts were being raised but no update PRs were ever opened, which is exactly how `services/commons` and `tests/e2e` fell behind while the seven service locks stayed current. The config lists all nine pipenv projects, groups minor/patch bumps into one PR per project to limit noise, and leaves security advisories on their own dedicated PRs. No `github-actions` ecosystem entry, since there are no workflows.

### 3. `services/commons/Pipfile.lock` — no action

27 alerts are still open against it, but all 27 are already satisfied by the versions on `main` as of c81753b (aiohttp 3.14.3, starlette 1.6.0, pyjwt 2.13.0, setuptools 84.0.0, pydantic-settings 2.15.0, idna 3.19). They will close on the next Dependabot scan, the same way the 87 alerts on the service locks closed on 2026-08-13.

## Test plan

Full stack via `./scripts/start.sh` (7 services + Dapr sidecars + MongoDB/Redis/RabbitMQ, all healthy), then `./scripts/run_e2e_tests.sh`:

```
account 4 · master-data 15 · terminal 8 · journal 3 · stock 15
report 31 · cart 59 · tests/e2e 31
Passed: 8   Failed: 0        (166 tests)
```

One new warning appears, and it needs no action: pyjwt 2.13.0 added `InsecureKeyLengthWarning`, which fires on the deliberately bogus 19-byte secret `"not-the-real-secret"` at `test_auth_boundary.py:151`. The real `DEV_SECRET_KEY` is 36 bytes and clears the threshold; there is no `filterwarnings = error`, so nothing fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB