### PR TITLE
fix(cart,commons): recover the loser of a concurrent finalize (#172)

### DIFF
--- a/services/account/Pipfile
+++ b/services/account/Pipfile
@@ -13,7 +13,7 @@ motor = "*"
 pytz = "*"
 pyjwt = "*"
 passlib = {extras = ["bcrypt"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 
 bcrypt = "==3.2.0"
 python-multipart = "*"

--- a/services/account/Pipfile.lock
+++ b/services/account/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "970532409b4de81a77b486cf57de3db140a3ac934bf1e803b1ee1cf24013de27"
+            "sha256": "a3319c2aee41f560546091e5c789b0d32c4715bc3d120d183917dfb97a039d1b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -667,9 +667,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {

--- a/services/cart/Pipfile
+++ b/services/cart/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/cart/Pipfile.lock
+++ b/services/cart/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85eabb46c8a819c1cd200de0fc18ab609f246d654d9942adcdeaf58ce4d1bb75"
+            "sha256": "a3989da3859d8b6aa748ef160fee7319eae028400ac2184ad9c5877a72b4aa18"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -659,9 +659,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {
@@ -3006,50 +3006,50 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:03bbecc7982af713d7499d4084bc03916413d17ffd45f89009348cc0c1d9e376",
-                "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace",
-                "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3",
-                "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5",
-                "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42",
-                "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f",
-                "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714",
-                "sha256:147a9442dcc2b7339ecdb1be2b3cdb098e90462e39425054053ebfb50d99125a",
-                "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08",
-                "sha256:17a3114bbdddb5e75e5784cdf318944636190cbbc72d357ef9fb1a8b0351f955",
-                "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52",
-                "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140",
-                "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21",
-                "sha256:31cff25b2aaedb5267e6e77b1e9be6b0ec4f622032de8a069202b8ffacda7dc2",
-                "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b",
-                "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560",
-                "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c",
-                "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b",
-                "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d",
-                "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e",
-                "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb",
-                "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f",
-                "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d",
-                "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304",
-                "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9",
-                "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8",
-                "sha256:a17e681224267880707c9ec9e730ad9a1ad2d65c371256843efba6cf48711b58",
-                "sha256:aab6bb5bee10f38ea688b95ba054396b67f613552d2c8378be7fcb2d2fba7646",
-                "sha256:afc66ccaef2a3c0bef6ca02aad40d29a39276389dad16a8eac36f9f385e4d057",
-                "sha256:bf917009a4a7457c7290225a019f4a0aa706d96accd2cfdba2418d3bc1fcde2f",
-                "sha256:c0c8aa2bf8f3911ef37b87deb1bbe225a310e6eb6522a16d77f5d8330c4f6fbe",
-                "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c",
-                "sha256:c28044972187245d7a309e4699319bfdbd2ffcbf7176d1d4ddf5adffb2dea80f",
-                "sha256:d178968a1a611df30549a717d1624cb38ca810347339e3e37b7baa6f6781a170",
-                "sha256:dabeb6fe1228d411994f300811edc6866fff0cdcbc9cef98a78f05ea0da42e37",
-                "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e",
-                "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4",
-                "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e",
-                "sha256:efe234a0fafb4b6b1602e9be9245b97c2bf06d67c07af5a4bc3c0438978b555c",
-                "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5",
-                "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784"
+                "sha256:00fd6a6da085beb90cdcdce6ed6e6973edf338d1ea63a807e213b1eb7013833d",
+                "sha256:09522cdc6a77376bc36988b531db3b568c8cb0b6ca7286d8316aab283888770f",
+                "sha256:105da41198a1990b18d566bd30656a19064d4c313e4c0dd8f0dd9714026e47f1",
+                "sha256:192bb756a8f62395b4fe47cbb853c171f20389d5226fbfa97128bb2f76abad8d",
+                "sha256:23ae710094fdcfcf715dae7054cd5abfefa4a527c5853d7b76ebb2541499c41a",
+                "sha256:27e6de8e593736210d2a9f1bbf766a5653aa4819c184f864ab9d1f8bd3590a60",
+                "sha256:28b68c24131545c1d13fd2178bbd065e67f09db885d8426adf1fbdf2b6b66372",
+                "sha256:3e0383361da2793ea332e2d12b753a32ac57b3b89c8c3a9c6dd04374ae142c0f",
+                "sha256:3f7f6da49911ffe75ae3f7a9a45619f205420cc6578aff02f8ca29ed1de10f14",
+                "sha256:42fb95008784a3b50c4b79e4488845d1950c57eef17ebc9c53a680084fb93da2",
+                "sha256:449727fc79f0b1317ec190632e13699b732d3f4704ea90c8e1339bb78e451bee",
+                "sha256:47030c08e39d690299e02973ac845d0f534121b3618efa9ce9599a512a1c97fa",
+                "sha256:5dbe120cfcfc8e6aed418f340c3d1ad4072253e17176503e363ddac27fcb2ac6",
+                "sha256:5ef166337880b0e78138bbd32fcbc5ab1da3337febe8d2a247f3690bcae3ede5",
+                "sha256:5fbd9deb0477aea769b7d83a4d953d77ef38972d5eddd5b922b614ee708b2104",
+                "sha256:6246f7a4b196bd054469f4fd4ffdac307974061f0d2b1ef4da87ddff13a7f885",
+                "sha256:64ed939d725876071823505b1c90074a86847a6e9be8617cec7ba759e0b86a7e",
+                "sha256:66ab8c5d8820aa378968c16b7a3cb051aca342eafa649c9a363182f572d75ccb",
+                "sha256:6df4bd16923d247c34e12dc394dab20d99d96aa2e15a6b163c2dda1dd582fff6",
+                "sha256:780a66db884c0e2b0e6b34b4900f86916945a7c03d3be40ec845b051fcc052cd",
+                "sha256:81793c9b12816ac7f8b71b366be36b7025fcf7205ec4a236642b15a82cb027ef",
+                "sha256:826f99c38f4bfcf7165885a0c59f03c6c25e0df8cdb0544f882cda61616fe845",
+                "sha256:919510e0d470c189cb84164b953f81e8a513aa2593fdc9e4982340838cd1099b",
+                "sha256:9217b1123f6aeec9ddf1789bffd83da3123546d551c164a99f862a5d1f5ac0f8",
+                "sha256:a2c5963a26e1fe47bdb3494ba2aa91904c7898873af400dc3bdcaa808a57783a",
+                "sha256:a38b221cc649a2daacaff9d629a2ba9c4a8967669d253f9a6a597f46d46732f0",
+                "sha256:a43e669d68fd8c10fe315812f7e1d262c6c00e9667f29f799a3771f9a3b5b41d",
+                "sha256:a84ac0010f054f3516710804a0c22026b4b0d30085d7666cfc2f30545775bf99",
+                "sha256:a91eb220d9ae6aa6d746d6dac5b4db35b1417903301b3315ba3275b19570be0b",
+                "sha256:add6e226c6568de6d0ea9f6abe6353072387afcf5f817610ea266495d0c1ee72",
+                "sha256:b08808d1196810f76928ad13d37dae18d92b1c9485c113628f41dbd6351413de",
+                "sha256:b40ef9b4873afb5d0dec02b8d2dfde1cf18c72337b60c99cb735961e0bac05c0",
+                "sha256:c2bf932006229788d6bb41963dfc0345cba6ee24141a39316bd52a283a7d115f",
+                "sha256:d97c96c79c389d1031c86f8e797b94db4fe647dfbfebdbe48247c1899dc930bb",
+                "sha256:dd25d6da3b3c8216080a0eefb3c01719913782690427fb9ba2ddad98ed8970f4",
+                "sha256:e36adea8ab93eb4d2076a47d5f4c7d7e1267eb9a4e33202da7ea71439a3bcaef",
+                "sha256:ebb513c9e47702525897148e38271f7b6bf12c61bd084cdddfd0e03b542f8100",
+                "sha256:ec5a5c01a54fc06b69da71164c9bba8cc71fde79bdd1b835bb734f96bca693f2",
+                "sha256:edf1bd7ed576319241b2b314eaa549cee3e3e0f81f46911086b387d03a303ad3",
+                "sha256:ef15a2f6258f809334a19c1fcce64648813066ceebe3f3f6077871483fd0f50d",
+                "sha256:fcc86414ee0e6b77416de81b8dead5900719b3f71b7875d8d1f87ae4e166a11f"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.5"
+            "version": "==8.6"
         }
     }
 }

--- a/services/cart/app/models/repositories/tranlog_repository.py
+++ b/services/cart/app/models/repositories/tranlog_repository.py
@@ -33,6 +33,52 @@ class TranlogRepository(AbstractRepository[BaseTransaction]):
         super().__init__(settings.DB_COLLECTION_NAME_TRAN_LOG, BaseTransaction, db)
         self.terminal_info = terminal_info
 
+    async def get_existing_finalize_async(self, tranlog: BaseTransaction) -> BaseTransaction:
+        """
+        The already-persisted tranlog for this finalize, if there is one.
+
+        Used twice: as the idempotent pre-check before inserting, and as the
+        recovery after a failed finalize, where the question is whether a
+        concurrent request already wrote the same transaction (issue #172).
+
+        Only a genuine retry of the SAME finalize is idempotent. A DIFFERENT
+        operation reusing this cart_id (e.g. a stale EnteringItem snapshot
+        replayed as a Cancel over a Completed sale) must NOT borrow the existing
+        record's result — that would silently swallow the new op while reporting
+        success (bug_008). Require the operation identity to match.
+
+        Args:
+            tranlog: The transaction log being finalized
+
+        Returns:
+            The persisted tranlog for the same finalize, or None
+
+        Raises:
+            FinalizeConflictException: The cart_id is already finalized as a
+                different operation.
+        """
+        if tranlog.cart_id is None:
+            return None
+
+        existing = await self.get_one_async(
+            {
+                "tenant_id": tranlog.tenant_id,
+                "store_code": tranlog.store_code,
+                "cart_id": tranlog.cart_id,
+            }
+        )
+        if existing is None:
+            return None
+        if self.__is_same_finalize(existing, tranlog):
+            return existing
+
+        message = (
+            f"cart_id={tranlog.cart_id} already finalized as a different transaction "
+            f"(existing type={existing.transaction_type}, cancelled={self.__is_cancelled(existing)}; "
+            f"incoming type={tranlog.transaction_type}, cancelled={self.__is_cancelled(tranlog)})"
+        )
+        raise FinalizeConflictException(message, logger)
+
     async def create_tranlog_async(self, tranlog: BaseTransaction) -> BaseTransaction:
         """
         Create a new transaction log entry in the database.
@@ -55,30 +101,10 @@ class TranlogRepository(AbstractRepository[BaseTransaction]):
             # tranlog BEFORE attempting the insert — the insert runs inside the
             # finalize transaction, and letting the duplicate hit the unique index
             # would abort that transaction (and recovery-within-it would fail).
-            if tranlog.cart_id is not None:
-                existing = await self.get_one_async(
-                    {
-                        "tenant_id": tranlog.tenant_id,
-                        "store_code": tranlog.store_code,
-                        "cart_id": tranlog.cart_id,
-                    }
-                )
-                if existing is not None:
-                    # Only a genuine retry of the SAME finalize is idempotent.
-                    # A DIFFERENT operation reusing this cart_id (e.g. a stale
-                    # EnteringItem snapshot replayed as a Cancel over a Completed
-                    # sale) must NOT borrow the existing record's result — that
-                    # would silently swallow the new op while reporting success
-                    # (bug_008). Require the operation identity to match.
-                    if self.__is_same_finalize(existing, tranlog):
-                        logger.warning(f"Idempotent finalize: tranlog for cart_id={tranlog.cart_id} already exists")
-                        return existing
-                    message = (
-                        f"cart_id={tranlog.cart_id} already finalized as a different transaction "
-                        f"(existing type={existing.transaction_type}, cancelled={self.__is_cancelled(existing)}; "
-                        f"incoming type={tranlog.transaction_type}, cancelled={self.__is_cancelled(tranlog)})"
-                    )
-                    raise FinalizeConflictException(message, logger)
+            existing = await self.get_existing_finalize_async(tranlog)
+            if existing is not None:
+                logger.warning(f"Idempotent finalize: tranlog for cart_id={tranlog.cart_id} already exists")
+                return existing
 
             tranlog.shard_key = self.__get_shard_key(tranlog)
             logger.debug(f"TranlogRepository.create_tranlog_async: tranlog->{tranlog}")

--- a/services/cart/app/services/tran_service.py
+++ b/services/cart/app/services/tran_service.py
@@ -337,30 +337,31 @@ class TranService:
             # tranlog in a fresh (non-transaction) session and return it. The finalize
             # is idempotent on cart_id, so the retry observes the same result instead
             # of a 500. The winner already published, so we do NOT publish again.
-            await self.tranlog_repository.abort_transaction()
-            self.tranlog_repository.set_session(session=None)
-            self.tranlog_delivery_status_repo.set_session(session=None)
-            existing = None
-            if tranlog.cart_id is not None:
-                existing = await self.tranlog_repository.get_one_async(
-                    {
-                        "tenant_id": tranlog.tenant_id,
-                        "store_code": tranlog.store_code,
-                        "cart_id": tranlog.cart_id,
-                    }
-                )
+            existing = await self.__recover_concurrent_finalize(tranlog)
             if existing is not None:
-                logger.warning(
-                    f"Concurrent finalize race for cart_id={tranlog.cart_id}; "
-                    "returning the winning tranlog idempotently"
-                )
-                return existing
+                return self.__apply_tranlog_to_cart(cart, existing)
             # The duplicate was on some other unique index (not the cart_id race) —
             # surface it as a real failure.
             message = f"Error creating tranlog: {e}"
             raise InternalErrorException(message, logger) from e
         except Exception as e:
-            await self.tranlog_repository.abort_transaction()
+            # The duplicate does not always surface at the insert (issue #172): with
+            # two identical finalizes in flight the loser's insert is buffered and
+            # the unique index rejects it at COMMIT, so the failure arrives here
+            # rather than as a DuplicateKeyException. Same race, same recovery —
+            # otherwise the caller is told the transaction failed while the
+            # transaction it asked for is sitting in the database.
+            existing = await self.__recover_concurrent_finalize(tranlog)
+            if existing is not None:
+                # Deliberately terse: the exception carries the whole tranlog, and
+                # one race must not put a full cart document in the log (issue #155).
+                logger.warning(
+                    "Finalize failed but the same finalize is already persisted "
+                    "(cart_id=%s, %s); returning it",
+                    tranlog.cart_id,
+                    type(e).__name__,
+                )
+                return self.__apply_tranlog_to_cart(cart, existing)
             message = f"Error creating tranlog: {e}"
             raise InternalErrorException(message, logger) from e
         finally:
@@ -371,14 +372,7 @@ class TranService:
         # Publish tranlog
         await self._publish_tranlog_async(event_message)
 
-        # Update cart_doc data
-        cart.transaction_no = tranlog.transaction_no
-        cart.receipt_no = tranlog.receipt_no
-        cart.staff = tranlog.staff
-        cart.receipt_text = tranlog.receipt_text
-        cart.journal_text = tranlog.journal_text
-
-        return tranlog
+        return self.__apply_tranlog_to_cart(cart, tranlog)
 
     async def get_tranlog_by_query_async(
         self,
@@ -1004,6 +998,62 @@ class TranService:
         )
 
         return tran
+
+    def __apply_tranlog_to_cart(self, cart: CartDocument, tranlog: BaseTransaction) -> BaseTransaction:
+        """
+        Copy the finalized transaction's identity onto the cart the caller holds.
+
+        The response is built from the cart, so this has to happen on the
+        recovery path too (issue #172): a caller that lost a concurrent finalize
+        race is handed the winner's tranlog, and without this its cart would
+        still carry no receipt_no and the response would fail validation.
+
+        Args:
+            cart: The cart document being finalized
+            tranlog: The persisted transaction log
+
+        Returns:
+            The transaction log, so callers can `return` this directly
+        """
+        cart.transaction_no = tranlog.transaction_no
+        cart.receipt_no = tranlog.receipt_no
+        cart.staff = tranlog.staff
+        cart.receipt_text = tranlog.receipt_text
+        cart.journal_text = tranlog.journal_text
+        return tranlog
+
+    async def __recover_concurrent_finalize(self, tranlog: BaseTransaction) -> BaseTransaction:
+        """
+        The tranlog a concurrent request already wrote for this finalize, if any.
+
+        Called after a failed finalize (issue #156 bug_001, issue #172). The
+        transaction is poisoned, so recovery cannot happen inside it: abort it,
+        drop the session, and look the record up in a fresh one. Returning it is
+        idempotent — the winner already published, so the caller must not publish
+        again.
+
+        Args:
+            tranlog: The transaction log this attempt was writing
+
+        Returns:
+            The persisted tranlog for the same finalize, or None when no
+            concurrent request wrote one (i.e. the failure was something else)
+
+        Raises:
+            FinalizeConflictException: The cart_id belongs to a different
+                finalize, which must surface as a 409 rather than a 500.
+        """
+        await self.tranlog_repository.abort_transaction()
+        self.tranlog_repository.set_session(session=None)
+        self.tranlog_delivery_status_repo.set_session(session=None)
+
+        existing = await self.tranlog_repository.get_existing_finalize_async(tranlog)
+        if existing is not None:
+            logger.warning(
+                f"Concurrent finalize race for cart_id={tranlog.cart_id}; "
+                "returning the winning tranlog idempotently"
+            )
+        return existing
 
     async def _receipt_range_async(self) -> tuple:
         """

--- a/services/cart/tests/e2e/test_concurrent_finalize.py
+++ b/services/cart/tests/e2e/test_concurrent_finalize.py
@@ -1,0 +1,155 @@
+# Copyright 2026 masa@kugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Two identical finalizes in flight at once (issue #172).
+
+The cart_id dedupe makes a *sequential* lost-ACK retry converge, and that is
+covered elsewhere. A client with a short timeout produces the concurrent version
+instead, where the loser's insert is rejected at commit. That used to answer 500
+- describing a cleanup error, not the real one - for a transaction the database
+had recorded exactly once.
+"""
+
+import asyncio
+import os
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+
+SYNTHETIC_SEQ_BASE = 9500
+
+
+@pytest.fixture
+def api_header():
+    return {"X-API-KEY": os.environ.get("API_KEY")}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _tenant_is_set_up(http_client):
+    """Make sure the tenant's indexes exist before racing two finalizes.
+
+    The session fixture drops the tenant database, and the unique index on
+    (tenant_id, store_code, cart_id) is what actually stops a second insert -
+    without it both concurrent writes land and the count assertion below is
+    measuring an unconfigured database rather than the fix.
+    """
+    from tests.e2e.test_cart import create_tenant, get_authentication_token
+
+    await create_tenant(http_client, await get_authentication_token())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _remove_synthetic_transactions(http_client):
+    """Leave the shared terminal's numbering as we found it (see #166 tests)."""
+    yield
+    from kugel_common.database import database as db_helper
+
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    await db["log_tran"].delete_many({"transaction_no": {"$gte": SYNTHETIC_SEQ_BASE}})
+
+
+async def _cart_ready_to_bill(http_client, terminal_id, header):
+    response = await http_client.post(
+        f"/api/v1/carts?terminal_id={terminal_id}",
+        json={"transaction_type": 101, "user_id": "99", "user_name": "Concurrent finalize"},
+        headers=header,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    cart_id = response.json()["data"]["cartId"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/lineItems?terminal_id={terminal_id}",
+        json=[{"itemCode": "49-01", "quantity": 1}],
+        headers=header,
+    )
+    snapshot = response.json()["data"]["signedSnapshot"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/subtotal?terminal_id={terminal_id}",
+        json={"signedSnapshot": snapshot, "payload": {}},
+        headers=header,
+    )
+    data = response.json()["data"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/payments?terminal_id={terminal_id}",
+        json={
+            "signedSnapshot": data["signedSnapshot"],
+            "payload": [{"paymentCode": "01", "amount": int(data["balanceAmount"])}],
+        },
+        headers=header,
+    )
+    return cart_id, response.json()["data"]["signedSnapshot"]
+
+
+async def _tranlog_count(cart_id):
+    from kugel_common.database import database as db_helper
+
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    return await db["log_tran"].count_documents({"cart_id": cart_id})
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_bills_both_succeed(http_client, api_header, opened_terminal_id):
+    cart_id, snapshot = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    request = {
+        "signedSnapshot": snapshot,
+        "payload": {
+            "seq": SYNTHETIC_SEQ_BASE + 1,
+            "receiptCounter": 41,
+            "transactionDatetime": "2026-08-20T09:00:00",
+        },
+    }
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+
+    first, second = await asyncio.gather(
+        http_client.post(url, json=request, headers=api_header),
+        http_client.post(url, json=request, headers=api_header),
+    )
+
+    assert first.status_code == status.HTTP_200_OK, first.text
+    assert second.status_code == status.HTTP_200_OK, second.text
+    # Both callers see the transaction that was written, with its numbers.
+    assert first.json()["data"]["transactionNo"] == second.json()["data"]["transactionNo"]
+    assert first.json()["data"]["receiptNo"] == second.json()["data"]["receiptNo"]
+    assert await _tranlog_count(cart_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_cancels_both_succeed(http_client, api_header, opened_terminal_id):
+    """A cancellation takes the same finalize path since #170."""
+    response = await http_client.post(
+        f"/api/v1/carts?terminal_id={opened_terminal_id}",
+        json={"transaction_type": 101, "user_id": "99", "user_name": "Concurrent cancel"},
+        headers=api_header,
+    )
+    cart_id = response.json()["data"]["cartId"]
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/lineItems?terminal_id={opened_terminal_id}",
+        json=[{"itemCode": "49-01", "quantity": 1}],
+        headers=api_header,
+    )
+    request = {
+        "signedSnapshot": response.json()["data"]["signedSnapshot"],
+        "payload": {
+            "seq": SYNTHETIC_SEQ_BASE + 2,
+            "receiptCounter": 42,
+            "transactionDatetime": "2026-08-20T09:01:00",
+        },
+    }
+    url = f"/api/v1/carts/{cart_id}/cancel?terminal_id={opened_terminal_id}"
+
+    first, second = await asyncio.gather(
+        http_client.post(url, json=request, headers=api_header),
+        http_client.post(url, json=request, headers=api_header),
+    )
+
+    assert first.status_code == status.HTTP_200_OK, first.text
+    assert second.status_code == status.HTTP_200_OK, second.text
+    assert first.json()["data"]["receiptNo"] == second.json()["data"]["receiptNo"]
+    assert await _tranlog_count(cart_id) == 1

--- a/services/cart/tests/unit/test_concurrent_finalize_recovery.py
+++ b/services/cart/tests/unit/test_concurrent_finalize_recovery.py
@@ -1,0 +1,130 @@
+# Copyright 2026 masa@kugel
+"""Recovery when a concurrent finalize wins the race (issue #172).
+
+Two identical finalizes in flight - what a POS with a short timeout produces -
+end with the loser's insert rejected by the unique cart_id index. When that
+rejection arrives at COMMIT rather than at the insert, the failure used to reach
+the generic handler, which aborted an already-committed session; the driver's
+complaint about that replaced the real error and the caller got a 500 for a
+transaction that had in fact been written exactly once.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.exceptions import FinalizeConflictException
+from app.services.tran_service import TranService
+from kugel_common.exceptions import DuplicateKeyException
+
+
+def _make_service():
+    terminal_info = MagicMock()
+    terminal_info.tenant_id = "test_tenant"
+    terminal_info.store_code = "S0001"
+    terminal_info.terminal_no = 1
+
+    with (
+        patch("app.services.tran_service.CartStrategyManager") as strategy_mgr,
+        patch("app.services.tran_service.PubsubManager"),
+    ):
+        strategy = MagicMock()
+        receipt_strategy = MagicMock()
+        receipt_strategy.name = "default"
+        strategy.load_strategies.return_value = [receipt_strategy]
+        strategy_mgr.return_value = strategy
+
+        svc = TranService(
+            terminal_info=terminal_info,
+            terminal_counter_repo=MagicMock(),
+            tranlog_repo=MagicMock(),
+            tranlog_delivery_status_repo=MagicMock(),
+            settings_master_repo=MagicMock(),
+            payment_master_repo=MagicMock(),
+            transaction_status_repo=MagicMock(),
+        )
+
+    svc.tranlog_repository.abort_transaction = AsyncMock()
+    svc.tranlog_repository.set_session = MagicMock()
+    svc.tranlog_delivery_status_repo.set_session = MagicMock()
+    return svc
+
+
+def _tranlog(cart_id="cart-172"):
+    return SimpleNamespace(cart_id=cart_id, tenant_id="test_tenant", store_code="S0001")
+
+
+async def _recover(svc, tranlog):
+    """The private recovery, reached through its mangled name."""
+    return await svc._TranService__recover_concurrent_finalize(tranlog)
+
+
+class TestRecovery:
+    @pytest.mark.asyncio
+    async def test_returns_the_winners_tranlog(self):
+        svc = _make_service()
+        winner = _tranlog()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+
+        assert await _recover(svc, _tranlog()) is winner
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_when_no_one_wrote_it(self):
+        # Then the failure was not this race and the caller must surface it.
+        svc = _make_service()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=None)
+
+        assert await _recover(svc, _tranlog()) is None
+
+    @pytest.mark.asyncio
+    async def test_aborts_and_drops_the_poisoned_session_first(self):
+        # The lookup has to run outside the failed transaction.
+        svc = _make_service()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=None)
+
+        await _recover(svc, _tranlog())
+
+        svc.tranlog_repository.abort_transaction.assert_awaited_once()
+        svc.tranlog_repository.set_session.assert_called_once_with(session=None)
+        svc.tranlog_delivery_status_repo.set_session.assert_called_once_with(session=None)
+
+    @pytest.mark.asyncio
+    async def test_a_different_operation_still_conflicts(self):
+        # bug_008 must not be softened into an idempotent success.
+        svc = _make_service()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(
+            side_effect=FinalizeConflictException("different op", None)
+        )
+
+        with pytest.raises(FinalizeConflictException):
+            await _recover(svc, _tranlog())
+
+
+class TestReachedFromBothFailureShapes:
+    """The race can surface at the insert or at the commit; both recover."""
+
+    def _armed(self, failure):
+        svc = _make_service()
+        svc.tranlog_delivery_status_repo.create_status_async = AsyncMock()
+        svc.tranlog_repository.start_transaction = AsyncMock(return_value=MagicMock())
+        svc.tranlog_repository.create_tranlog_async = AsyncMock(side_effect=failure)
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_duplicate_at_insert(self):
+        svc = self._armed(DuplicateKeyException("dup", "log_tran", {}, None))
+        winner = _tranlog()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+
+        assert await _recover(svc, _tranlog()) is winner
+
+    @pytest.mark.asyncio
+    async def test_failure_at_commit(self):
+        # A commit-time rejection is not a DuplicateKeyException, which is why it
+        # used to fall through to the generic handler and become a 500.
+        svc = self._armed(RuntimeError("E11000 duplicate key error at commit"))
+        winner = _tranlog()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+
+        assert await _recover(svc, _tranlog()) is winner

--- a/services/cart/tests/unit/test_concurrent_finalize_recovery.py
+++ b/services/cart/tests/unit/test_concurrent_finalize_recovery.py
@@ -14,9 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.exceptions import FinalizeConflictException
+from app.exceptions import FinalizeConflictException, InternalErrorException
+from app.models.documents.cart_document import CartDocument
 from app.services.tran_service import TranService
-from kugel_common.exceptions import DuplicateKeyException
+from kugel_common.enums import TransactionType
+from kugel_common.exceptions import CannotCreateException, DuplicateKeyException
+from kugel_common.models.documents.base_tranlog import BaseTransaction
 
 
 def _make_service():
@@ -24,6 +27,7 @@ def _make_service():
     terminal_info.tenant_id = "test_tenant"
     terminal_info.store_code = "S0001"
     terminal_info.terminal_no = 1
+    terminal_info.staff = SimpleNamespace(id="S001", name="Staff1")
 
     with (
         patch("app.services.tran_service.CartStrategyManager") as strategy_mgr,
@@ -53,6 +57,35 @@ def _make_service():
 
 def _tranlog(cart_id="cart-172"):
     return SimpleNamespace(cart_id=cart_id, tenant_id="test_tenant", store_code="S0001")
+
+
+def _cart(cart_id="cart-172"):
+    """A cart carrying its finalize context, i.e. on the stateless path."""
+    cart = CartDocument()
+    cart.cart_id = cart_id
+    cart.transaction_type = TransactionType.NormalSales.value
+    cart.business_date = "20260820"
+    cart.seq = 7
+    cart.receipt_counter = 7
+    cart.receipt_no = 111117
+    cart.transaction_datetime = "2026-08-20T10:00:00"
+    cart.sales = CartDocument.SalesInfo()
+    cart.sales.total_amount_with_tax = 110.0
+    cart.user = None
+    return cart
+
+
+def _persisted_winner(cart_id="cart-172"):
+    """What a concurrent request already committed for the same finalize."""
+    winner = BaseTransaction()
+    winner.cart_id = cart_id
+    winner.tenant_id = "test_tenant"
+    winner.store_code = "S0001"
+    winner.transaction_no = 7
+    winner.receipt_no = 111117
+    winner.receipt_text = "R"
+    winner.journal_text = "J"
+    return winner
 
 
 async def _recover(svc, tranlog):
@@ -102,29 +135,58 @@ class TestRecovery:
 
 
 class TestReachedFromBothFailureShapes:
-    """The race can surface at the insert or at the commit; both recover."""
+    """The race can surface at the insert or at the commit; both must recover.
 
-    def _armed(self, failure):
+    These drive create_tranlog_async itself rather than the private helper: what
+    is being checked is that the exception handlers route to recovery at all, so
+    a test that calls the helper directly would pass with the routing broken.
+    """
+
+    def _armed(self, failure, winner):
+        """A service whose finalize fails with `failure` while `winner` is persisted."""
         svc = _make_service()
         svc.tranlog_delivery_status_repo.create_status_async = AsyncMock()
         svc.tranlog_repository.start_transaction = AsyncMock(return_value=MagicMock())
         svc.tranlog_repository.create_tranlog_async = AsyncMock(side_effect=failure)
+        svc.tranlog_repository.commit_transaction = AsyncMock()
+        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+        svc._get_setting_value_async = AsyncMock(return_value=None)
+        svc._publish_tranlog_async = AsyncMock()
+        svc.receipt_data_strategy = MagicMock()
+        svc.receipt_data_strategy.make_receipt_data.return_value = MagicMock(receipt_text="R", journal_text="J")
         return svc
 
     @pytest.mark.asyncio
     async def test_duplicate_at_insert(self):
-        svc = self._armed(DuplicateKeyException("dup", "log_tran", {}, None))
-        winner = _tranlog()
-        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+        winner = _persisted_winner()
+        svc = self._armed(DuplicateKeyException("dup", "log_tran", {}, None), winner)
+        cart = _cart()
 
-        assert await _recover(svc, _tranlog()) is winner
+        result = await svc.create_tranlog_async(cart)
+
+        assert result is winner
+        assert cart.receipt_no == winner.receipt_no  # the response is built from the cart
+        svc._publish_tranlog_async.assert_not_awaited()  # the winner already published
 
     @pytest.mark.asyncio
     async def test_failure_at_commit(self):
-        # A commit-time rejection is not a DuplicateKeyException, which is why it
-        # used to fall through to the generic handler and become a 500.
-        svc = self._armed(RuntimeError("E11000 duplicate key error at commit"))
-        winner = _tranlog()
-        svc.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+        # The duplicate arrives wrapped (CannotCreateException, "Failed to save
+        # document to database"), which is why it used to reach the generic
+        # handler and become a 500.
+        winner = _persisted_winner()
+        svc = self._armed(CannotCreateException("wrapped duplicate", "log_tran", {}, None), winner)
+        cart = _cart()
 
-        assert await _recover(svc, _tranlog()) is winner
+        result = await svc.create_tranlog_async(cart)
+
+        assert result is winner
+        assert cart.receipt_no == winner.receipt_no
+        svc._publish_tranlog_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failure_with_nothing_persisted_still_fails(self):
+        # Recovery must not turn an unrelated failure into a success.
+        svc = self._armed(RuntimeError("disk on fire"), winner=None)
+
+        with pytest.raises(InternalErrorException):
+            await svc.create_tranlog_async(_cart())

--- a/services/commons/src/kugel_common/__about__.py
+++ b/services/commons/src/kugel_common/__about__.py
@@ -14,5 +14,5 @@
 # SPDX-FileCopyrightText: 2024-present kugel-masa <masa@kugel.cloud>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.70"
+__version__ = "0.1.71"
 

--- a/services/commons/src/kugel_common/models/repositories/abstract_repository.py
+++ b/services/commons/src/kugel_common/models/repositories/abstract_repository.py
@@ -128,22 +128,42 @@ class AbstractRepository(ABC, Generic[Tdocument]):
     async def abort_transaction(self):
         """
         Abort the current transaction
-        
+
         Cancels all operations performed within the transaction and
         rolls back any changes made.
-        
+
+        Callers abort from an exception handler, so this must not raise an
+        exception of its own: doing so replaces the failure being handled with
+        a cleanup error and loses the reason (issue #172). A commit that fails
+        leaves the session set but past the point where it can be aborted -
+        the driver answers "Cannot call abortTransaction after calling
+        commitTransaction" - so the abort is attempted only while the session
+        is still in a transaction, and any failure is logged rather than
+        propagated. The session is released either way.
+
         Raises:
             RepositoryException: If no transaction is in progress
         """
         logger.debug(f"Aborting transaction for collection: {self.collection_name}")
-        if self.session is not None:
-            await self.session.abort_transaction()
-            await self.session.end_session()
-            self.session = None
-        else:
+        if self.session is None:
             raise RepositoryException(
                 "No transaction started", self.collection_name, logger
             )
+        try:
+            if getattr(self.session, "in_transaction", True):
+                await self.session.abort_transaction()
+        except Exception as e:
+            logger.warning(
+                f"Transaction abort skipped for collection {self.collection_name}: {e}"
+            )
+        finally:
+            try:
+                await self.session.end_session()
+            except Exception as e:
+                logger.warning(
+                    f"Session close failed for collection {self.collection_name}: {e}"
+                )
+            self.session = None
 
     def set_session(self, session: AsyncIOMotorClientSession):
         """

--- a/services/commons/tests/unit/test_abort_transaction.py
+++ b/services/commons/tests/unit/test_abort_transaction.py
@@ -1,0 +1,101 @@
+# Copyright 2026 masa@kugel
+"""abort_transaction must not replace the failure it is cleaning up after (#172).
+
+Callers abort from an exception handler. A commit that fails leaves the session
+set but past the point where it can be aborted, and the driver's complaint about
+that ("Cannot call abortTransaction after calling commitTransaction") used to
+surface instead of the error that actually broke the operation - a concurrent
+duplicate finalize came back as a 500 whose message described the cleanup.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kugel_common.exceptions import RepositoryException
+from kugel_common.models.repositories.abstract_repository import AbstractRepository
+
+
+class _Repo(AbstractRepository):
+    """Minimal concrete repository; only the session plumbing is exercised."""
+
+    def __init__(self):
+        super().__init__("test_collection", MagicMock, MagicMock())
+
+
+def _session(in_transaction=True, abort_error=None, end_error=None):
+    session = MagicMock()
+    session.in_transaction = in_transaction
+    session.abort_transaction = AsyncMock(side_effect=abort_error)
+    session.end_session = AsyncMock(side_effect=end_error)
+    return session
+
+
+class TestAbortsWhatCanBeAborted:
+    @pytest.mark.asyncio
+    async def test_aborts_a_live_transaction(self):
+        repo = _Repo()
+        repo.session = session = _session()
+
+        await repo.abort_transaction()
+
+        session.abort_transaction.assert_awaited_once()
+        session.end_session.assert_awaited_once()
+        assert repo.session is None
+
+    @pytest.mark.asyncio
+    async def test_skips_the_abort_once_the_transaction_has_ended(self):
+        # This is the committed-then-failed case: the session is still set, but
+        # aborting it is what the driver refuses.
+        repo = _Repo()
+        repo.session = session = _session(in_transaction=False)
+
+        await repo.abort_transaction()
+
+        session.abort_transaction.assert_not_awaited()
+        session.end_session.assert_awaited_once()
+        assert repo.session is None
+
+
+class TestNeverMasksTheOriginalFailure:
+    @pytest.mark.asyncio
+    async def test_a_refused_abort_does_not_raise(self):
+        repo = _Repo()
+        repo.session = _session(
+            abort_error=RuntimeError("Cannot call abortTransaction after calling commitTransaction")
+        )
+
+        await repo.abort_transaction()  # must not raise
+
+        assert repo.session is None
+
+    @pytest.mark.asyncio
+    async def test_a_failing_session_close_does_not_raise(self):
+        repo = _Repo()
+        repo.session = _session(end_error=RuntimeError("connection gone"))
+
+        await repo.abort_transaction()  # must not raise
+
+        assert repo.session is None
+
+    @pytest.mark.asyncio
+    async def test_the_session_is_released_even_when_cleanup_fails(self):
+        # Otherwise the next request on this repository would think a
+        # transaction is still in progress.
+        repo = _Repo()
+        repo.session = _session(abort_error=RuntimeError("boom"), end_error=RuntimeError("boom"))
+
+        await repo.abort_transaction()
+
+        assert repo.session is None
+
+
+class TestNoTransaction:
+    @pytest.mark.asyncio
+    async def test_aborting_without_a_transaction_is_still_an_error(self):
+        # A caller aborting when it never started one is a bug worth surfacing.
+        repo = _Repo()
+        repo.session = None
+
+        with pytest.raises(RepositoryException):
+            await repo.abort_transaction()

--- a/services/journal/Pipfile
+++ b/services/journal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 
 httpx = "*"
 aiohttp = "*"

--- a/services/journal/Pipfile.lock
+++ b/services/journal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "186f35edf42e2315d6d2eea5357b602b54e626efed2c2fb9f8bcccda0d5c0550"
+            "sha256": "be39d86ddbc3fdc5bd0605d1927fd76e83082661ab8a11e46b8c278fb5e08ae2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -544,9 +544,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {

--- a/services/master-data/Pipfile
+++ b/services/master-data/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 httpx = "*"
 wcwidth = "*"
 debugpy = "*"

--- a/services/master-data/Pipfile.lock
+++ b/services/master-data/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d0311d5cd269ce4aeaff7dd284bcee82d9ea785058c6d4391c05802cbb8f7a0e"
+            "sha256": "2a8bc46a5ceed52417bed326f208ef80cff42ef8b06ca798df3e9d003828cfca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -258,9 +258,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {

--- a/services/report/Pipfile
+++ b/services/report/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/report/Pipfile.lock
+++ b/services/report/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "133ad346d56f65bcaab095d0345f13f071c3961271a52288afe980d8ff8567f8"
+            "sha256": "ff4fe124e3133af070115ccc47ef1109d21f64457d83ecc985dd74108e0224b5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -722,9 +722,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {

--- a/services/stock/Pipfile
+++ b/services/stock/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/stock/Pipfile.lock
+++ b/services/stock/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65073829b9c32f0f045e0000fe933e0a068efe0358f4adf7b204f2c7f3178a2d"
+            "sha256": "9995b5f09741e24623789989734d0e6f8d5ba461f8ad9de6be1ba01a20344abd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -731,9 +731,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {

--- a/services/terminal/Pipfile
+++ b/services/terminal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.70-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/terminal/Pipfile.lock
+++ b/services/terminal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "61266d089ca06c3f781d6001e432731ee10c04a1d4641f90b817973636376c2a"
+            "sha256": "a41104f456bae6783954393d08618253d05c4d08384c9495e498224276d7ef67"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -553,9 +553,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.70-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
             "hashes": [
-                "sha256:4d00f28e41767914b0868c20af66d529ae563716590b54d3579950d070ff7e0a"
+                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
             ]
         },
         "motor": {


### PR DESCRIPTION
Closes #172.

## Problem

Two identical finalizes in flight — the shape a POS with a short timeout produces — left the data correct and handed one caller a 500 whose message described a cleanup error:

```
A -> 200
B -> 500  "Cannot call abortTransaction after calling commitTransaction"
tranlogs for cart: 1
```

Reproduced on both `bill` and `cancel` with `asyncio.gather` of two identical requests.

## Two faults, stacked

**`abort_transaction` raised.** Callers abort from an exception handler, so an abort that raises replaces the failure being handled and loses the reason — the log did not even say what really went wrong. A session whose commit has run is past the point where it can be aborted and the driver says so. It now aborts only while the session is still in a transaction, logs anything that goes wrong rather than propagating it, and releases the session either way.

**The recovery did not cover the shape the race actually takes.** bug_001 handles a `DuplicateKeyException` from the insert. In the concurrent case the duplicate arrives *wrapped* — `CannotCreateException`, "Failed to save document to database" — so it reached the generic handler, which had no recovery at all. Both paths now go through one:

```python
existing = await self.__recover_concurrent_finalize(tranlog)
if existing is not None:
    return self.__apply_tranlog_to_cart(cart, existing)
```

abort → drop the poisoned session → ask whether a concurrent request already wrote this finalize. If it did, return it (the winner already published, so we do not publish again). A cart_id belonging to a **different** finalize still raises `FinalizeConflictException` (bug_008); a failure with no persisted counterpart still surfaces as an error.

The lookup moved into `TranlogRepository.get_existing_finalize_async`, which is the same check the insert pre-check runs — idempotency is now decided in one place instead of two.

## A third defect the fix uncovered

With the 500 out of the way, the loser's response failed validation with `receipt_no=None`. The recovery returned the winner's tranlog but skipped copying its numbers onto the cart the response is built from — the early `return existing` had always skipped it, invisible while nobody reached that path. Factored into `__apply_tranlog_to_cart`, used by the normal and the recovery path alike.

## Result

```
A -> 200   transactionNo=9501  receiptNo=111151
B -> 200   transactionNo=9501  receiptNo=111151
tranlogs for cart: 1
```

with the recovery visible in the log:

```
Concurrent finalize race for cart_id=…; returning the winning tranlog idempotently
Finalize failed but the same finalize is already persisted (cart_id=…, CannotCreateException); returning it
```

That log line is deliberately terse — the exception carries the whole tranlog, and one race must not put a full cart document in the log (#155).

## Testing

- **6 commons unit** — aborts a live transaction, skips the abort once the transaction has ended, never raises (refused abort, failed close), releases the session anyway, and still rejects an abort with no transaction at all
- **6 cart unit** — recovery returns the winner, returns nothing when the failure was something else, aborts before looking up, still conflicts for a different operation, and is reached from both failure shapes
- **2 e2e** — two identical bills and two identical cancels raced with `asyncio.gather`: both callers get 200 with the same numbers, and exactly one tranlog exists

The e2e module ensures tenant setup first: the unique index on `(tenant_id, store_code, cart_id)` is what stops the second insert, and without it the test would be measuring an unconfigured database.

| tier | result |
|---|---|
| unit | 8/8 suites pass |
| integration | 7/7 suites pass |
| e2e | 8/8 suites pass |

kugel_common 0.1.71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB