### PR TITLE
feat(cart): detect a finalize that falls into the other numbering series (#168)

### DIFF
--- a/docs/en/cart/client-carried-cart.md
+++ b/docs/en/cart/client-carried-cart.md
@@ -183,6 +183,40 @@ Pre-#166 clients keep working: they carry no counter, send their number under th
 old `receipt_no` name at open (numerically the same value — they counted 1, 2, 3
 with no wrap), and their receipt numbers are recorded as sent.
 
+## Two numbering series while DUAL mode is on (#168)
+
+The finalize path branches per **transaction**, not per terminal:
+
+| request | numbers come from |
+|---|---|
+| carries a finalize context | the terminal's running `receipt_counter` |
+| carries none | cart's own `terminal_counter` collection |
+
+A phase 2 terminal whose snapshot signing has degraded — `SNAPSHOT_HMAC_KEYS`
+unset, malformed, or mid-rotation — is issued no snapshot, so it cannot carry
+anything and its next sale is numbered from the *other* series. That series knows
+nothing about how far the terminal has advanced, so it can print a receipt number
+the terminal has already issued.
+
+This is **detected, not blocked**: refusing the finalize would stop a store
+selling over a key misconfiguration, and the posture for numbering integrity here
+is audit detection rather than enforcement (spec 156 Q58). A finalize that falls
+into the server-side series while the terminal has one of its own logs at ERROR
+
+```
+Finalize numbered from the server-side series while the terminal has its own
+(issue #168): cart_id=… reason=signing_degraded terminal_receipt_counter=…
+```
+
+and writes a `numbering_fallback` record to the restore audit trail
+(`log_cart_restore`), with `reject_reason` naming which condition fired
+(`signing_degraded` / `no_carried_context`).
+
+`CART_REQUEST_SNAPSHOT_MODE=REQUIRED` removes the window entirely — a
+snapshot-less mutating request is rejected, so there is no second series to fall
+into. Until then, a degraded signing key is an incident to fix, and now one that
+is visible per transaction rather than only in the startup log.
+
 ## Configuration
 
 | Variable | Default | Purpose |

--- a/docs/en/cart/client-carried-cart.md
+++ b/docs/en/cart/client-carried-cart.md
@@ -209,8 +209,14 @@ Finalize numbered from the server-side series while the terminal has its own
 ```
 
 and writes a `numbering_fallback` record to the restore audit trail
-(`log_cart_restore`), with `reject_reason` naming which condition fired
-(`signing_degraded` / `no_carried_context`).
+(`log_cart_restore`), with `reject_reason` naming which condition fired (`signing_degraded`,
+`snapshot_without_finalize_context`, or `no_carried_context`).
+
+One case is deliberately out of reach: a phase 2 terminal that has not numbered
+anything yet, whose signing is healthy and which carries no snapshot at all,
+looks exactly like a phase 1 terminal. Open seeds every terminal's counter with
+zero, so treating zero as "has its own series" would report every legacy
+finalize as an incident instead.
 
 `CART_REQUEST_SNAPSHOT_MODE=REQUIRED` removes the window entirely — a
 snapshot-less mutating request is rejected, so there is no second series to fall

--- a/docs/en/terminal/api-specification.md
+++ b/docs/en/terminal/api-specification.md
@@ -785,6 +785,7 @@ Optional filtering by store code is supported.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -869,6 +870,7 @@ Requires token authentication (no terminal ID/API key needed since the terminal 
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -949,6 +951,7 @@ or X-API-KEY), the api_key is always masked even if the flag is set.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1382,6 +1385,7 @@ This endpoint updates the description of a specific terminal.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1466,6 +1470,7 @@ The function mode determines what operations are available on the terminal.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1646,6 +1651,7 @@ Returns an X-New-Token header with updated JWT reflecting the new staff assignme
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1718,6 +1724,7 @@ Returns an X-New-Token header with updated JWT reflecting staff removal.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |

--- a/docs/ja/cart/client-carried-cart.md
+++ b/docs/ja/cart/client-carried-cart.md
@@ -176,7 +176,9 @@ Finalize numbered from the server-side series while the terminal has its own
 (issue #168): cart_id=… reason=signing_degraded terminal_receipt_counter=…
 ```
 
-リストア監査証跡（`log_cart_restore`）に `numbering_fallback` レコードを書く（`reject_reason` はどちらの条件で発火したか——`signing_degraded` / `no_carried_context`——を示す）。
+リストア監査証跡（`log_cart_restore`）に `numbering_fallback` レコードを書く（`reject_reason` はどの条件で発火したかを示す——`signing_degraded` / `snapshot_without_finalize_context` / `no_carried_context`）。
+
+1 つだけ意図的に検知できないケースがある。まだ 1 件も採番していない phase 2 端末が、署名は正常でスナップショットも運ばずに確定した場合、phase 1 端末と完全に見分けがつかない。open は全端末のカウンタを 0 でシードするため、0 を「自前の系列を持つ」と扱うと**すべてのレガシー確定をインシデントとして報告してしまう**。
 
 `CART_REQUEST_SNAPSHOT_MODE=REQUIRED` にすればこの窓は完全に消える（スナップショットなしの更新系リクエストが拒否されるため、落ちる先の系列が存在しない）。それまでは、署名鍵の縮退は修正すべきインシデントであり、起動ログだけでなく**取引単位で可視化される**ようになった。
 

--- a/docs/ja/cart/client-carried-cart.md
+++ b/docs/ja/cart/client-carried-cart.md
@@ -158,6 +158,28 @@ receipt_no = RECEIPT_NO_START_VALUE + ((receipt_counter - 1) mod レンジ幅)
 
 #166 以前のクライアントもそのまま動作する。カウンタを持たず、open では旧来の `receipt_no` 名で同じ値を送り（1, 2, 3 と巻かずに数えていた＝通算値そのもの）、レシート番号は送られた値のまま記録される。
 
+## DUAL モード中は採番系列が 2 本ある (#168)
+
+確定経路の分岐は**端末単位ではなく取引単位**である。
+
+| リクエスト | 採番元 |
+|---|---|
+| finalize context を運ぶ | 端末の通算カウンタ `receipt_counter` |
+| 運ばない | cart 自身の `terminal_counter` コレクション |
+
+スナップショット署名が縮退した phase 2 端末（`SNAPSHOT_HMAC_KEYS` の未設定・不正・ローテーション途中）にはスナップショットが発行されないため、何も運べず、次の売上が**もう一方の系列**で採番される。その系列は端末がどこまで進んでいるかを知らないため、**端末が既に発行したレシート番号を再び印字しうる**。
+
+これは**遮断せず検知する**。鍵の設定ミスで店舗の販売を止める方が有害であり、採番の整合性に対する本システムの姿勢は「強制ではなく監査検知」だからである（spec 156 Q58）。端末が自前の系列を持っているのにサーバー系列で採番された確定は ERROR ログを出し、
+
+```
+Finalize numbered from the server-side series while the terminal has its own
+(issue #168): cart_id=… reason=signing_degraded terminal_receipt_counter=…
+```
+
+リストア監査証跡（`log_cart_restore`）に `numbering_fallback` レコードを書く（`reject_reason` はどちらの条件で発火したか——`signing_degraded` / `no_carried_context`——を示す）。
+
+`CART_REQUEST_SNAPSHOT_MODE=REQUIRED` にすればこの窓は完全に消える（スナップショットなしの更新系リクエストが拒否されるため、落ちる先の系列が存在しない）。それまでは、署名鍵の縮退は修正すべきインシデントであり、起動ログだけでなく**取引単位で可視化される**ようになった。
+
 ## 設定
 
 | 環境変数 | 既定値 | 内容 |

--- a/docs/ja/terminal/api-specification.md
+++ b/docs/ja/terminal/api-specification.md
@@ -744,6 +744,7 @@ Delete Storeを削除します。対象をシステムから削除します。
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -825,6 +826,7 @@ Delete Storeを削除します。対象をシステムから削除します。
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -905,6 +907,7 @@ or X-API-KEY), the api_key is always masked even if the flag is set.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1324,6 +1327,7 @@ Represents termin |
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1405,6 +1409,7 @@ Represents termin |
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1585,6 +1590,7 @@ Returns an X-New-Token header with updated JWT reflecting the new staff assignme
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |
@@ -1657,6 +1663,7 @@ Returns an X-New-Token header with updated JWT reflecting staff removal.
 | `businessDate` | string | No | - |
 | `openCounter` | integer | Yes | - |
 | `businessCounter` | integer | Yes | - |
+| `receiptCounter` | integer | No | - |
 | `initialAmount` | number | No | - |
 | `physicalAmount` | number | No | - |
 | `staff` | BaseStaff | No | - |

--- a/docs/openapi/index.json
+++ b/docs/openapi/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-20T17:34:17+09:00",
+  "generated_at": "2026-08-20T22:58:42+09:00",
   "services": [
     {
       "name": "account",

--- a/docs/openapi/terminal.json
+++ b/docs/openapi/terminal.json
@@ -4101,6 +4101,17 @@
             "type": "integer",
             "title": "Businesscounter"
           },
+          "receiptCounter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiptcounter"
+          },
           "initialAmount": {
             "anyOf": [
               {
@@ -4824,6 +4835,17 @@
           "businessCounter": {
             "type": "integer",
             "title": "Businesscounter"
+          },
+          "receiptCounter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiptcounter"
           },
           "initialAmount": {
             "anyOf": [

--- a/services/account/Pipfile
+++ b/services/account/Pipfile
@@ -13,7 +13,7 @@ motor = "*"
 pytz = "*"
 pyjwt = "*"
 passlib = {extras = ["bcrypt"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 
 bcrypt = "==3.2.0"
 python-multipart = "*"

--- a/services/account/Pipfile.lock
+++ b/services/account/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3319c2aee41f560546091e5c789b0d32c4715bc3d120d183917dfb97a039d1b"
+            "sha256": "95a192c0d829ce38396208a5e0740847c91f57e11facd52671952e05680e0ddc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -667,9 +667,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/cart/Pipfile
+++ b/services/cart/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/cart/Pipfile.lock
+++ b/services/cart/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3989da3859d8b6aa748ef160fee7319eae028400ac2184ad9c5877a72b4aa18"
+            "sha256": "a1498bff4fc3f5d12e5ec5cdd4e59210f7595b845814518a00e9b38ba6dbbb19"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -659,9 +659,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/cart/app/services/cart_service.py
+++ b/services/cart/app/services/cart_service.py
@@ -350,15 +350,11 @@ class CartService(ICartService):
             cart_doc.receipt_no = receipt_no
             cart_doc.receipt_counter = receipt_counter
             cart_doc.transaction_datetime = transaction_datetime
-        elif self._stateless:
-            # A phase 2 terminal that cancels without a context falls back to the
-            # server-side counters, which is the collision this issue is about.
-            logger.warning(
-                "Cancel on the stateless path carried no finalize context "
-                "(cart_id=%s); numbering falls back to the server-side counters, "
-                "which can collide with a carried transaction in this open session",
-                self.cart_id,
-            )
+        else:
+            # No carried context: the numbers come from the server-side series
+            # (issue #170 gave cancel a carried path; issue #168 is about the two
+            # series coexisting while DUAL mode is on).
+            await self.__audit_numbering_fallback_async(self.cart_id, "cancel")
 
         # Create transaction log
         tranlog = await self.tran_service.create_tranlog_async(cart_doc)
@@ -822,6 +818,8 @@ class CartService(ICartService):
             cart_doc.receipt_no = receipt_no
             cart_doc.receipt_counter = receipt_counter
             cart_doc.transaction_datetime = transaction_datetime
+        else:
+            await self.__audit_numbering_fallback_async(self.cart_id, "bill")
 
         # Create transaction log
         tranlog = await self.tran_service.create_tranlog_async(cart_doc)
@@ -946,6 +944,56 @@ class CartService(ICartService):
         self.item_master_repo.set_item_master_documents(snapshot_cart.masters.items)
         self.tax_master_repo.set_tax_master_documents(snapshot_cart.masters.taxes)
         self.state_manager.set_state(snapshot_cart.status)
+
+    async def __audit_numbering_fallback_async(self, cart_id: str, api_path: str) -> None:
+        """
+        Record a finalize that will be numbered from the server-side series when
+        the terminal has a series of its own (issue #168).
+
+        DUAL mode keeps two independent receipt-number sources: a carried
+        finalize numbers from the terminal's running counter, a snapshot-less one
+        from cart's `terminal_counter`. The branch is per *transaction*, so a
+        phase 2 terminal whose snapshot signing has degraded - an unset,
+        malformed or mid-rotation SNAPSHOT_HMAC_KEYS - silently falls into the
+        other series and can print a receipt number it has already issued.
+
+        Detected, not blocked: refusing the finalize would stop a store selling
+        over a key misconfiguration, and this codebase's posture for numbering
+        integrity is audit detection rather than enforcement (spec 156 Q58).
+        `CART_REQUEST_SNAPSHOT_MODE=REQUIRED` is what removes the window.
+
+        Args:
+            cart_id: The cart being finalized
+            api_path: API path of the finalize, for the audit trail
+
+        Returns:
+            None
+        """
+        signing_degraded = snapshot_service.get_snapshot_signer() is None
+        terminal_counter = getattr(self.terminal_info, "receipt_counter", None)
+        terminal_numbers_its_own = bool(terminal_counter)
+        if not (signing_degraded or terminal_numbers_its_own):
+            # A phase 1 terminal with no series of its own: the server-side
+            # numbering is simply how it works, and nothing can collide.
+            return
+
+        reason = "signing_degraded" if signing_degraded else "no_carried_context"
+        logger.error(
+            "Finalize numbered from the server-side series while the terminal has "
+            "its own (issue #168): cart_id=%s reason=%s terminal_receipt_counter=%s "
+            "stateless=%s. Receipt numbers from the two series can collide; fix the "
+            "snapshot signing key, or move to CART_REQUEST_SNAPSHOT_MODE=REQUIRED.",
+            cart_id,
+            reason,
+            terminal_counter,
+            self._stateless,
+        )
+        await self.__add_restore_audit_async(
+            result="numbering_fallback",
+            audit_meta={"cart_id": cart_id},
+            reject_reason=reason,
+            api_path=api_path,
+        )
 
     async def __add_restore_audit_async(
         self, result: str, audit_meta: dict, reject_reason: str = None, diverged: bool = False, api_path: str = None

--- a/services/cart/app/services/cart_service.py
+++ b/services/cart/app/services/cart_service.py
@@ -971,13 +971,29 @@ class CartService(ICartService):
         """
         signing_degraded = snapshot_service.get_snapshot_signer() is None
         terminal_counter = getattr(self.terminal_info, "receipt_counter", None)
+        # A counter above zero means this terminal has numbered receipts itself.
+        # Zero is deliberately not enough: open seeds every terminal with zero, so
+        # `is not None` would flag every phase 1 finalize as an incident.
         terminal_numbers_its_own = bool(terminal_counter)
-        if not (signing_degraded or terminal_numbers_its_own):
+        # A request that carried a snapshot but no finalize context is a phase 2
+        # client whatever its counter says - the case a zero counter would miss.
+        carried_a_snapshot = self._stateless
+        if not (signing_degraded or terminal_numbers_its_own or carried_a_snapshot):
             # A phase 1 terminal with no series of its own: the server-side
             # numbering is simply how it works, and nothing can collide.
+            #
+            # Blind spot, stated rather than papered over: a phase 2 terminal that
+            # has not numbered anything yet (counter zero), whose signing is
+            # healthy, and which carries no snapshot at all is indistinguishable
+            # from a phase 1 terminal here. Its first sale would not be flagged.
             return
 
-        reason = "signing_degraded" if signing_degraded else "no_carried_context"
+        if signing_degraded:
+            reason = "signing_degraded"
+        elif carried_a_snapshot:
+            reason = "snapshot_without_finalize_context"
+        else:
+            reason = "no_carried_context"
         logger.error(
             "Finalize numbered from the server-side series while the terminal has "
             "its own (issue #168): cart_id=%s reason=%s terminal_receipt_counter=%s "

--- a/services/cart/tests/unit/test_cancel_carried_numbering.py
+++ b/services/cart/tests/unit/test_cancel_carried_numbering.py
@@ -112,15 +112,19 @@ class TestFallback:
         assert doc.receipt_counter is None
 
     @pytest.mark.asyncio
-    async def test_stateless_cancel_without_a_context_is_reported(self, caplog):
+    async def test_a_terminal_with_its_own_series_is_reported(self, caplog):
+        # #168: the finalize will be numbered from the server-side series while
+        # this terminal numbers its own, so the two can collide.
         doc = _cart_doc()
         svc = _arm(_make_cart_service(stateless=True), doc)
+        svc.terminal_info.receipt_counter = 42
+        svc.cart_restore_log_repo = None  # audit unavailable; the log still has to say it
 
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("ERROR"):
             await svc.cancel_transaction_async()
 
-        assert "carried no finalize context" in caplog.text
-        assert "collide" in caplog.text
+        assert "server-side series" in caplog.text
+        assert "issue #168" in caplog.text
 
 
 class TestGuard:

--- a/services/cart/tests/unit/test_cancel_carried_numbering.py
+++ b/services/cart/tests/unit/test_cancel_carried_numbering.py
@@ -45,6 +45,7 @@ def _make_cart_service(stateless=True):
             store_info_repo=AsyncMock(),
             tran_service=AsyncMock(),
             cart_id="cart-170",
+            cart_restore_log_repo=AsyncMock(),
         )
 
     svc._stateless = stateless
@@ -137,3 +138,22 @@ class TestGuard:
             await svc.cancel_transaction_async(
                 seq=7, receipt_no=111117, receipt_counter=7, transaction_datetime="2026-08-20T12:00:00"
             )
+
+
+class TestBillAlsoAudits:
+    """The wiring, not just the helper: removing the call from bill must fail."""
+
+    @pytest.mark.asyncio
+    async def test_bill_without_a_carried_context_audits_the_fallback(self):
+        doc = _cart_doc()
+        doc.balance_amount = 0
+        svc = _arm(_make_cart_service(stateless=True), doc)
+        svc.terminal_info.receipt_counter = 42
+        svc._CartService__subtotal_async = AsyncMock(return_value=doc)
+        svc._CartService__cache_cart_async = AsyncMock()
+
+        await svc.bill_async()
+
+        svc.cart_restore_log_repo.add_record_async.assert_awaited_once()
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["result"] == "numbering_fallback"
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["api_path"] == "bill"

--- a/services/cart/tests/unit/test_numbering_fallback_audit.py
+++ b/services/cart/tests/unit/test_numbering_fallback_audit.py
@@ -1,0 +1,130 @@
+# Copyright 2026 masa@kugel
+"""Detection of a finalize that falls into the other numbering series (#168).
+
+DUAL mode keeps two independent receipt-number sources: a carried finalize
+numbers from the terminal's running counter, a snapshot-less one from cart's
+own counter. The branch is per transaction, so a phase 2 terminal whose snapshot
+signing has degraded silently falls into the other series and can print a number
+it has already issued. This is detected rather than blocked - refusing the
+finalize would stop a store selling over a key misconfiguration.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_service(stateless=False, terminal_receipt_counter=None):
+    from app.services.cart_service import CartService
+
+    terminal_info = MagicMock()
+    terminal_info.tenant_id = "test_tenant"
+    terminal_info.store_code = "S0001"
+    terminal_info.terminal_no = 1
+    terminal_info.receipt_counter = terminal_receipt_counter
+
+    with (
+        patch("app.services.cart_service.CartStrategyManager") as strategy_mgr,
+        patch("app.services.cart_service.PromotionMasterWebRepository"),
+    ):
+        strategy = MagicMock()
+        strategy.load_strategies.return_value = []
+        strategy_mgr.return_value = strategy
+
+        svc = CartService(
+            terminal_info=terminal_info,
+            cart_repo=AsyncMock(),
+            terminal_counter_repo=AsyncMock(),
+            settings_master_repo=AsyncMock(),
+            tax_master_repo=AsyncMock(),
+            item_master_repo=AsyncMock(),
+            payment_master_repo=AsyncMock(),
+            store_info_repo=AsyncMock(),
+            tran_service=AsyncMock(),
+            cart_id="cart-168",
+            cart_restore_log_repo=AsyncMock(),
+        )
+    svc._stateless = stateless
+    return svc
+
+
+async def _detect(svc, api_path="bill"):
+    await svc._CartService__audit_numbering_fallback_async("cart-168", api_path)
+
+
+def _signer(present):
+    return patch(
+        "app.services.cart_service.snapshot_service.get_snapshot_signer", return_value=object() if present else None
+    )
+
+
+class TestWhenItFires:
+    @pytest.mark.asyncio
+    async def test_terminal_with_its_own_series(self):
+        svc = _make_service(terminal_receipt_counter=42)
+        with _signer(present=True):
+            await _detect(svc)
+
+        svc.cart_restore_log_repo.add_record_async.assert_awaited_once()
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["result"] == "numbering_fallback"
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["reject_reason"] == "no_carried_context"
+
+    @pytest.mark.asyncio
+    async def test_degraded_signing_even_for_an_unknown_terminal(self):
+        # No snapshots are issued at all, so every phase 2 client degrades - the
+        # terminal's counter may not have reached this service yet.
+        svc = _make_service(terminal_receipt_counter=None)
+        with _signer(present=False):
+            await _detect(svc)
+
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["reject_reason"] == "signing_degraded"
+
+    @pytest.mark.asyncio
+    async def test_the_api_path_reaches_the_audit(self):
+        svc = _make_service(terminal_receipt_counter=7)
+        with _signer(present=True):
+            await _detect(svc, api_path="cancel")
+
+        assert svc.cart_restore_log_repo.add_record_async.await_args.kwargs["api_path"] == "cancel"
+
+    @pytest.mark.asyncio
+    async def test_the_log_names_the_issue_and_the_remedy(self, caplog):
+        svc = _make_service(terminal_receipt_counter=42)
+        with _signer(present=True), caplog.at_level("ERROR"):
+            await _detect(svc)
+
+        assert "issue #168" in caplog.text
+        assert "CART_REQUEST_SNAPSHOT_MODE=REQUIRED" in caplog.text
+
+
+class TestWhenItStaysQuiet:
+    @pytest.mark.asyncio
+    async def test_a_phase_1_terminal_is_not_flagged(self):
+        # Server-side numbering is simply how this terminal works; there is no
+        # second series to collide with.
+        svc = _make_service(terminal_receipt_counter=None)
+        with _signer(present=True):
+            await _detect(svc)
+
+        svc.cart_restore_log_repo.add_record_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_zero_counter_is_not_a_series(self):
+        # Seeded at open and never advanced: the terminal has not numbered anything.
+        svc = _make_service(terminal_receipt_counter=0)
+        with _signer(present=True):
+            await _detect(svc)
+
+        svc.cart_restore_log_repo.add_record_async.assert_not_awaited()
+
+
+class TestAuditFailureIsNotFatal:
+    @pytest.mark.asyncio
+    async def test_a_missing_audit_repository_does_not_break_the_finalize(self, caplog):
+        svc = _make_service(terminal_receipt_counter=42)
+        svc.cart_restore_log_repo = None
+
+        with _signer(present=True), caplog.at_level("ERROR"):
+            await _detect(svc)  # must not raise
+
+        assert "issue #168" in caplog.text

--- a/services/cart/tests/unit/test_numbering_fallback_audit.py
+++ b/services/cart/tests/unit/test_numbering_fallback_audit.py
@@ -109,13 +109,33 @@ class TestWhenItStaysQuiet:
         svc.cart_restore_log_repo.add_record_async.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_a_zero_counter_is_not_a_series(self):
-        # Seeded at open and never advanced: the terminal has not numbered anything.
+    async def test_a_zero_counter_alone_is_not_a_series(self):
+        # Open seeds every terminal with zero, phase 1 included, so zero on its
+        # own cannot mean "numbers its own receipts" - treating it that way would
+        # report every legacy finalize as an incident. A phase 2 terminal sitting
+        # at zero is caught by the snapshot signal instead (see below).
         svc = _make_service(terminal_receipt_counter=0)
         with _signer(present=True):
             await _detect(svc)
 
         svc.cart_restore_log_repo.add_record_async.assert_not_awaited()
+
+
+class TestTheSnapshotSignal:
+    """What a zero counter would otherwise miss."""
+
+    @pytest.mark.asyncio
+    async def test_a_snapshot_without_a_finalize_context_is_flagged(self):
+        # Carrying a snapshot makes this a phase 2 client whatever its counter
+        # says, so the finalize going to the server-side series is an incident.
+        svc = _make_service(stateless=True, terminal_receipt_counter=0)
+        with _signer(present=True):
+            await _detect(svc)
+
+        assert (
+            svc.cart_restore_log_repo.add_record_async.await_args.kwargs["reject_reason"]
+            == "snapshot_without_finalize_context"
+        )
 
 
 class TestAuditFailureIsNotFatal:

--- a/services/commons/src/kugel_common/__about__.py
+++ b/services/commons/src/kugel_common/__about__.py
@@ -14,5 +14,5 @@
 # SPDX-FileCopyrightText: 2024-present kugel-masa <masa@kugel.cloud>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.71"
+__version__ = "0.1.72"
 

--- a/services/commons/src/kugel_common/security.py
+++ b/services/commons/src/kugel_common/security.py
@@ -184,6 +184,10 @@ def terminal_claims_to_terminal_info(claims: dict) -> TerminalInfoDocument:
         open_counter=claims.get("open_counter"),
         business_counter=claims.get("business_counter"),
         receipt_no=claims.get("receipt_no"),
+        # Issue #166: the terminal's running receipt counter. Carried back so a
+        # service can tell a terminal that numbers its own receipts from one that
+        # relies on server-side numbering (issue #168).
+        receipt_counter=claims.get("receipt_counter"),
     )
 
     # Reconstruct staff if present in claims

--- a/services/journal/Pipfile
+++ b/services/journal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 
 httpx = "*"
 aiohttp = "*"

--- a/services/journal/Pipfile.lock
+++ b/services/journal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "be39d86ddbc3fdc5bd0605d1927fd76e83082661ab8a11e46b8c278fb5e08ae2"
+            "sha256": "9a949c2e191a2022efa4a25fd992fb3a7160f3bf8dbc88f20150b12217d8a7f3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -544,9 +544,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/master-data/Pipfile
+++ b/services/master-data/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 httpx = "*"
 wcwidth = "*"
 debugpy = "*"

--- a/services/master-data/Pipfile.lock
+++ b/services/master-data/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2a8bc46a5ceed52417bed326f208ef80cff42ef8b06ca798df3e9d003828cfca"
+            "sha256": "78113a6a5c0a25f106eb447f51ce27b6d11ca73883b11c08348fef6453e502de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -258,9 +258,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/report/Pipfile
+++ b/services/report/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/report/Pipfile.lock
+++ b/services/report/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ff4fe124e3133af070115ccc47ef1109d21f64457d83ecc985dd74108e0224b5"
+            "sha256": "aa7fe8b921f399458f5a5f528c3bc43673cd624e26dad31b516041c104cf53f8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -722,9 +722,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/stock/Pipfile
+++ b/services/stock/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/stock/Pipfile.lock
+++ b/services/stock/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9995b5f09741e24623789989734d0e6f8d5ba461f8ad9de6be1ba01a20344abd"
+            "sha256": "c1ce95624dd9137c9c2b0caf1c13079bafe632d3f7a3e570aeced20749650543"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -731,9 +731,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/terminal/Pipfile
+++ b/services/terminal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.71-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.72-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/terminal/Pipfile.lock
+++ b/services/terminal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a41104f456bae6783954393d08618253d05c4d08384c9495e498224276d7ef67"
+            "sha256": "cea78f90d6d755cb54ebe31b20e32a807a9d4d0ee8c65c37bd693dba10e5c05a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -553,9 +553,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.71-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.72-py3-none-any.whl",
             "hashes": [
-                "sha256:147242bc32e62ed21ad52aa140cb7fd27014bce87c7d5a86ddd791682256581d"
+                "sha256:8ce086463055d9100e8f35a5304f7738ba3e69443aac836a6bbd58669512baba"
             ]
         },
         "motor": {

--- a/services/terminal/app/api/common/schemas.py
+++ b/services/terminal/app/api/common/schemas.py
@@ -162,6 +162,11 @@ class BaseTerminal(BaseSchemmaModel):
     business_date: Optional[str] = None
     open_counter: int
     business_counter: int
+    # The terminal's running receipt counter (issue #166). Exposed so a service
+    # reached with an API key - which has no JWT claims to read - can tell a
+    # terminal that numbers its own receipts from one that relies on server-side
+    # numbering (issue #168).
+    receipt_counter: Optional[int] = None
     initial_amount: Optional[float] = None
     physical_amount: Optional[float] = None
     staff: Optional[BaseStaff] = None

--- a/services/terminal/app/api/common/schemas_transformer.py
+++ b/services/terminal/app/api/common/schemas_transformer.py
@@ -31,6 +31,7 @@ class SchemasTransformer:
             business_date=terminal_info.business_date,
             open_counter=terminal_info.open_counter,
             business_counter=terminal_info.business_counter,
+            receipt_counter=getattr(terminal_info, "receipt_counter", None),
             initial_amount=terminal_info.initial_amount,
             physical_amount=terminal_info.physical_amount,
             api_key=terminal_info.api_key if include_api_key else mask_api_key(terminal_info.api_key),


### PR DESCRIPTION
Closes #168. The last of the three backend items the stateless migration needs.

## Problem

DUAL mode keeps **two independent receipt-number sources**, and the branch is per *transaction*:

| request | numbers come from |
|---|---|
| carries a finalize context | the terminal's running `receipt_counter` |
| carries none | cart's own `terminal_counter` collection |

A phase 2 terminal whose snapshot signing has degraded — `SNAPSHOT_HMAC_KEYS` unset, malformed, or mid-rotation — is issued no snapshot, so it cannot carry anything and its next sale is numbered from the other series. That series knows nothing about how far the terminal has advanced, so it can print a receipt number the terminal has already issued.

Observed on the running stack while verifying this change:

```
carried bill        -> receiptNo 111170   (counter 60)
snapshot-less bill  -> receiptNo 111160   (the other series, which will reach 111170 in time)
```

## Detected, not blocked

Refusing the finalize would stop a store selling over a key misconfiguration, and the posture for numbering integrity here is audit detection rather than enforcement (spec 156 Q58). `CART_REQUEST_SNAPSHOT_MODE=REQUIRED` is what removes the window — a snapshot-less mutating request is rejected, so there is no second series to fall into.

Until then, a finalize that will be server-numbered **while the terminal has a series of its own** logs at ERROR:

```
Finalize numbered from the server-side series while the terminal has its own
(issue #168): cart_id=… reason=no_carried_context terminal_receipt_counter=60
stateless=False. Receipt numbers from the two series can collide; fix the
snapshot signing key, or move to CART_REQUEST_SNAPSHOT_MODE=REQUIRED.
```

and writes a `numbering_fallback` record to the restore audit trail with `reject_reason` naming which condition fired (`signing_degraded` / `no_carried_context`). A phase 1 terminal — no second series, nothing to collide with — is not flagged.

## Two gaps left over from #166, closed here

Knowing whether a terminal numbers its own receipts turned out not to be possible:

- the terminal token's `receipt_counter` claim was never mapped back into `TerminalInfoDocument` (the claim was added in #166, the reverse mapping was not)
- the terminal service's detail response did not expose the field at all, so a service reached with an **API key** — which has no claims to read — could not see it either

Both are fixed, which is also what made the first version of this detection silently never fire. Generated API docs regenerated for the response change.

## Testing

- **7 unit** — fires for a terminal with its own series and for degraded signing; stays quiet for a phase 1 terminal and for a counter of 0 (seeded at open, never advanced); survives a missing audit repository; and says the issue number and the remedy in the log
- **verified live** — the ERROR line and the `numbering_fallback` audit record both appear for a snapshot-less finalize from a terminal carrying counter 60

| tier | result |
|---|---|
| unit | 8/8 suites pass |
| integration | 7/7 suites pass |
| e2e | 8/8 suites pass |

kugel_common 0.1.72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB