### PR TITLE
fix(commons): say what blocks a tenant setup, and finish the collections that can be (#185)

### DIFF
--- a/services/account/Pipfile
+++ b/services/account/Pipfile
@@ -13,7 +13,7 @@ motor = "*"
 pytz = "*"
 pyjwt = "*"
 passlib = {extras = ["bcrypt"], version = "*"}
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 
 bcrypt = "==3.2.0"
 python-multipart = "*"

--- a/services/account/Pipfile.lock
+++ b/services/account/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ea556962fff9c8a6628c90c42afbbfa672dea411c4b8306c281a7979516a6df"
+            "sha256": "8c7a4e6e8d9f206486c8504b0fc41c17ab873aff5b63af9c3a5b165b64a1da76"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -667,9 +667,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/account/app/database/database_setup.py
+++ b/services/account/app/database/database_setup.py
@@ -81,21 +81,19 @@ async def create_request_log_collection(tenant_id: str):
 
 
 async def create_collections(tenant_id: str):
+    """Create every collection this service needs for a tenant.
+
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
     """
-    Create all required collections for a new tenant
-
-    This function should be extended when new collections are added to the system.
-    Each collection creation should be added to this function.
-
-    Args:
-        tenant_id: The tenant identifier
-
-    Returns:
-        None
-    """
-    await create_user_account_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
-    # Add more collections here as the system grows
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_user_account_collection,
+            create_request_log_collection,
+        ],
+    )
 
 
 async def execute(tenant_id: str):

--- a/services/cart/Pipfile
+++ b/services/cart/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/cart/Pipfile.lock
+++ b/services/cart/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0e6bfc2b4edb5c79dee8c065ef3bd99b95a7a90b3f4eeb0b2efac919f192e2b3"
+            "sha256": "3059613bb207985a6d07db87340d973da4876e7e6ddf9e952e6ac7a3ecc5ee10"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -659,9 +659,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/cart/app/api/v1/tenant.py
+++ b/services/cart/app/api/v1/tenant.py
@@ -52,7 +52,11 @@ async def create_tenant(
         await database_setup.execute(tenant_id=tenant_id)
 
     except Exception as e:
-        message = f"Error creating tenant: {tenant_id}"
+        # Carry the reason, not just the tenant. Which collection and which index
+        # could not be built - and, for a unique index, the documents in the way -
+        # already exist one frame down; discarding them left an operator with a
+        # bare 500 and nowhere to start (issue #185).
+        message = f"Error creating tenant: {tenant_id}: {e}"
         logger.error(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message)
 

--- a/services/cart/app/database/database_setup.py
+++ b/services/cart/app/database/database_setup.py
@@ -260,8 +260,7 @@ async def backfill_status_tran_business_counter(tenant_id: str) -> None:
 
     if filled or unresolved:
         logger.info(
-            f"status_tran business_counter backfill for tenant {tenant_id}: "
-            f"filled={filled} unresolved={unresolved}"
+            f"status_tran business_counter backfill for tenant {tenant_id}: filled={filled} unresolved={unresolved}"
         )
 
 
@@ -330,27 +329,24 @@ async def create_cart_restore_log_collection(tenant_id: str):
 
 
 async def create_collections(tenant_id: str):
+    """Create every collection this service needs for a tenant.
+
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
     """
-    Creates all required collections for the Cart service.
-
-    This function is a convenience wrapper that calls all the individual
-    collection creation functions.
-
-    Args:
-        tenant_id: The tenant identifier used to create the database name
-
-    Returns:
-        None
-    """
-    await create_cache_cart_collection(tenant_id)
-    await create_terminal_counter_collection(tenant_id)
-    await create_tran_log_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
-    await create_tran_log_delivery_status_collection(tenant_id)
-    await create_status_tran_collection(tenant_id)
-    await create_cart_restore_log_collection(tenant_id)
-
-    # add more collections here
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_cache_cart_collection,
+            create_terminal_counter_collection,
+            create_tran_log_collection,
+            create_request_log_collection,
+            create_tran_log_delivery_status_collection,
+            create_status_tran_collection,
+            create_cart_restore_log_collection,
+        ],
+    )
 
 
 async def execute(tenant_id: str):

--- a/services/cart/tests/integration/test_index_blocking_report.py
+++ b/services/cart/tests/integration/test_index_blocking_report.py
@@ -1,0 +1,131 @@
+# Copyright 2026 masa@kugel
+"""Naming the data that blocks a unique index (issue #185).
+
+Here rather than in `services/commons` because the answer comes from MongoDB: the
+point is which documents are actually in the way, and a mock would only return
+what the test put in it.
+
+Collections are created before their indexes, so anything already written has to
+satisfy them. When it does not, the index can never be built and tenant setup
+fails on every retry — which was reported as `Error creating tenant: T6216` and
+nothing else. Observed on real data: a journal held transaction 1 four times.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from kugel_common.database import database as db_helper
+from kugel_common.database.database import (
+    BLOCKING_DUPLICATE_SAMPLE,
+    create_collection_with_indexes_async,
+    find_blocking_duplicates_async,
+)
+from kugel_common.database.database_exceptions import DatabaseException
+
+pytestmark = pytest.mark.asyncio
+
+KEYS = {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "business_counter": 1, "transaction_no": 1}
+
+
+def _tranlog(transaction_no, **over):
+    doc = {
+        "tenant_id": "T0001",
+        "store_code": "5678",
+        "terminal_no": 9,
+        "business_counter": 1,
+        "transaction_no": transaction_no,
+    }
+    doc.update(over)
+    return doc
+
+
+@pytest_asyncio.fixture
+async def collection():
+    """A throwaway collection in its own database."""
+    db_name = f"db_probe_185_{uuid.uuid4().hex[:8]}"
+    name = "log_tran"
+    db = await db_helper.get_db_async(db_name)
+    yield db_name, name, db
+    client = await db_helper.get_client_async()
+    await client.drop_database(db_name)
+
+
+class TestFindingWhatIsInTheWay:
+    async def test_the_colliding_key_values_are_reported(self, collection):
+        _, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(1), _tranlog(1), _tranlog(2), _tranlog(2), _tranlog(3)])
+
+        found = await find_blocking_duplicates_async(db, name, KEYS)
+
+        counts = {d["n"] for d in found}
+        assert counts == {3, 2}, f"expected the 3x and the 2x collision, got {found}"
+
+    async def test_a_collection_with_no_collisions_reports_none(self, collection):
+        _, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(2), _tranlog(3)])
+
+        assert await find_blocking_duplicates_async(db, name, KEYS) == []
+
+    async def test_documents_outside_a_partial_filter_are_not_blocking(self, collection):
+        # A partial index does not index them, so they cannot be what stops it
+        # being built - naming them would send an operator after the wrong rows.
+        _, name, db = collection
+        await db[name].insert_many(
+            [
+                _tranlog(1, cart_id="c1"),
+                _tranlog(1, cart_id="c1"),  # blocking
+                _tranlog(2),  # no cart_id at all - outside the filter
+                _tranlog(2),
+            ]
+        )
+
+        found = await find_blocking_duplicates_async(
+            db, name, KEYS, partial_filter_expression={"cart_id": {"$type": "string"}}
+        )
+
+        assert len(found) == 1, f"documents outside the partial filter were reported: {found}"
+        assert found[0]["n"] == 2
+
+    async def test_the_sample_is_bounded(self, collection):
+        _, name, db = collection
+        await db[name].insert_many([_tranlog(n) for n in range(40) for _ in range(2)])
+
+        found = await find_blocking_duplicates_async(db, name, KEYS)
+
+        assert len(found) == BLOCKING_DUPLICATE_SAMPLE
+
+
+class TestWhatTheSetupSays:
+    async def test_the_failure_names_the_collection_and_the_documents(self, collection):
+        db_name, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(1), _tranlog(1)])
+
+        with pytest.raises(DatabaseException) as caught:
+            await create_collection_with_indexes_async(
+                db_name=db_name,
+                collection_name=name,
+                index_keys_list=[{"keys": KEYS, "unique": True}],
+                index_name="probe_index",
+            )
+
+        message = str(caught.value)
+        assert name in message, "the failure did not name the collection"
+        assert "x3" in message, "the failure did not say how many documents collide"
+        assert "transaction_no" in message and "T0001" in message, (
+            f"the failure did not name the colliding key values: {message}"
+        )
+
+    async def test_a_collection_that_can_be_indexed_succeeds(self, collection):
+        db_name, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(2)])
+
+        await create_collection_with_indexes_async(
+            db_name=db_name,
+            collection_name=name,
+            index_keys_list=[{"keys": KEYS, "unique": True}],
+            index_name="probe_index",
+        )
+
+        present = [tuple(tuple(k) for k in i["key"]) for i in (await db[name].index_information()).values()]
+        assert tuple(KEYS.items()) in present

--- a/services/cart/tests/integration/test_index_blocking_report.py
+++ b/services/cart/tests/integration/test_index_blocking_report.py
@@ -129,3 +129,65 @@ class TestWhatTheSetupSays:
 
         present = [tuple(tuple(k) for k in i["key"]) for i in (await db[name].index_information()).values()]
         assert tuple(KEYS.items()) in present
+
+
+class TestAnIndexWithTheRightKeysAndTheWrongOptions:
+    async def test_a_non_unique_index_on_the_required_keys_is_reported(self, collection):
+        """The same failure wearing a disguise.
+
+        `createIndexes` will not change an existing index's options - it refuses
+        with IndexOptionsConflict, which the ensure loop logs as a warning. A
+        check that only compares keys then reports success over a uniqueness
+        constraint that is not being enforced: exactly the fail-open this
+        verification exists to close.
+        """
+        db_name, name, db = collection
+        # Both halves are needed for the fail-open: the duplicates stop the unique
+        # index being built, and the non-unique index leaves the keys present so a
+        # keys-only check finds nothing wrong. MongoDB lets the two coexist under
+        # different names, so this is not hypothetical.
+        await db[name].insert_many([_tranlog(1), _tranlog(1), _tranlog(2)])
+        await db[name].create_index(list(KEYS.items()), name="already_here", unique=False)
+
+        with pytest.raises(DatabaseException) as caught:
+            await create_collection_with_indexes_async(
+                db_name=db_name,
+                collection_name=name,
+                index_keys_list=[{"keys": KEYS, "unique": True}],
+                index_name="probe_index",
+            )
+
+        message = str(caught.value)
+        assert "is unique" in message, f"the mismatch was not reported: {message}"
+        assert "x2" in message, "the failure did not say what is keeping it non-unique"
+        assert name in message
+
+    async def test_a_non_unique_index_is_fine_when_none_was_required(self, collection):
+        db_name, name, db = collection
+        await db[name].create_index(list(KEYS.items()), name="already_here", unique=False)
+
+        await create_collection_with_indexes_async(
+            db_name=db_name,
+            collection_name=name,
+            index_keys_list=[{"keys": KEYS}],
+            index_name="probe_index",
+        )
+
+    async def test_a_unique_index_is_found_whatever_order_it_is_listed_in(self, collection):
+        """MongoDB lets a unique and a non-unique index share a key pattern.
+
+        Both are then reported for the same keys, so a check that keeps only one
+        of them decides by listing order - and fails a collection whose
+        constraint is present and enforced.
+        """
+        db_name, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(2)])
+        await db[name].create_index(list(KEYS.items()), name="the_unique_one", unique=True)
+        await db[name].create_index(list(KEYS.items()), name="listed_after_it", unique=False)
+
+        await create_collection_with_indexes_async(
+            db_name=db_name,
+            collection_name=name,
+            index_keys_list=[{"keys": KEYS, "unique": True}],
+            index_name="probe_index",
+        )

--- a/services/commons/src/kugel_common/__about__.py
+++ b/services/commons/src/kugel_common/__about__.py
@@ -14,5 +14,5 @@
 # SPDX-FileCopyrightText: 2024-present kugel-masa <masa@kugel.cloud>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.75"
+__version__ = "0.1.76"
 

--- a/services/commons/src/kugel_common/database/database.py
+++ b/services/commons/src/kugel_common/database/database.py
@@ -18,6 +18,7 @@ This module provides a set of asynchronous utilities for interacting with MongoD
 using the Motor driver. It handles connection management, database and collection
 operations, and provides unified error handling.
 """
+
 # database.py
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from logging import getLogger
@@ -39,27 +40,29 @@ client: AsyncIOMotorClient = None
 _client_lock = asyncio.Lock()
 
 # Type variable for generic return type
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 def with_connection_retry(func: Callable[..., T]) -> Callable[..., T]:
     """
     Decorator that handles connection errors and retries the operation
     after resetting the client connection.
-    
+
     The number of retry attempts is controlled by the DB_CONNECTION_RETRY_COUNT
     setting (default: 1).
-    
+
     Args:
         func: The async function to wrap
-        
+
     Returns:
         The wrapped function with retry logic
     """
+
     @wraps(func)
     async def wrapper(*args, **kwargs):
         last_exception = None
         retry_count = settings.DB_CONNECTION_RETRY_COUNT
-        
+
         # Try once, then retry up to retry_count times
         for attempt in range(1 + retry_count):
             try:
@@ -67,7 +70,9 @@ def with_connection_retry(func: Callable[..., T]) -> Callable[..., T]:
             except (ConnectionFailure, ServerSelectionTimeoutError) as e:
                 last_exception = e
                 if attempt < retry_count:
-                    logger.warning(f"Connection error in {func.__name__} (attempt {attempt + 1}): {e}. Resetting client...")
+                    logger.warning(
+                        f"Connection error in {func.__name__} (attempt {attempt + 1}): {e}. Resetting client..."
+                    )
                     await reset_client_async()
                     # Continue to next retry attempt
                 else:
@@ -80,23 +85,25 @@ def with_connection_retry(func: Callable[..., T]) -> Callable[..., T]:
             except Exception as e:
                 # Re-raise non-connection errors immediately
                 raise
-        
+
         # Should not reach here, but just in case
         if last_exception:
             raise last_exception
+
     return wrapper
+
 
 async def get_client_async() -> AsyncIOMotorClient:
     """
     Create and get MongoDB client instance asynchronously
-    
+
     Creates a singleton client instance connecting to MongoDB or returns
     the existing client if already connected. Connection validation is
     done lazily when actual operations are performed.
-    
+
     Returns:
         AsyncIOMotorClient: MongoDB client instance
-        
+
     Raises:
         DatabaseException: If connection to MongoDB fails
     """
@@ -107,12 +114,10 @@ async def get_client_async() -> AsyncIOMotorClient:
                 client = AsyncIOMotorClient(
                     # Connection string
                     host=MONGODB_URI,
-                    
                     # Connection pool management
                     maxPoolSize=settings.DB_MAX_POOL_SIZE,
                     minPoolSize=settings.DB_MIN_POOL_SIZE,
                     maxIdleTimeMS=settings.DB_MAX_IDLE_TIME_MS,
-                    
                     # Timeout settings
                     serverSelectionTimeoutMS=settings.DB_SERVER_SELECTION_TIMEOUT_MS,
                     connectTimeoutMS=settings.DB_CONNECT_TIMEOUT_MS,
@@ -121,21 +126,24 @@ async def get_client_async() -> AsyncIOMotorClient:
                 # Initial connection test
                 info = await client.server_info()
                 logger.info(f"Connected to MongoDB {info}")
-                logger.info(f"Connection pool settings: maxPoolSize={settings.DB_MAX_POOL_SIZE}, "
-                           f"minPoolSize={settings.DB_MIN_POOL_SIZE}, "
-                           f"maxIdleTimeMS={settings.DB_MAX_IDLE_TIME_MS}")
+                logger.info(
+                    f"Connection pool settings: maxPoolSize={settings.DB_MAX_POOL_SIZE}, "
+                    f"minPoolSize={settings.DB_MIN_POOL_SIZE}, "
+                    f"maxIdleTimeMS={settings.DB_MAX_IDLE_TIME_MS}"
+                )
             except Exception as e:
                 client = None
                 message = f"Failed to connect to MongoDB: uri->{MONGODB_URI}"
                 raise DatabaseException(message, logger, e) from e
         return client
 
+
 async def close_client_async():
     """
     Close the MongoDB client connection asynchronously
-    
+
     Properly closes the MongoDB client connection to release resources.
-    
+
     Raises:
         DatabaseException: If closing the connection fails
     """
@@ -143,7 +151,7 @@ async def close_client_async():
     try:
         if client is not None:
             client.close()
-            logger.info("Database connection closed")     
+            logger.info("Database connection closed")
     except Exception as e:
         message = "Failed to close database connection"
         raise DatabaseException(message, logger, e) from e
@@ -151,10 +159,11 @@ async def close_client_async():
         client = None
         logger.info("MongoDB client set to None")
 
+
 async def reset_client_async():
     """
     Reset the MongoDB client connection
-    
+
     Closes the existing client connection and resets it to None,
     forcing a new connection to be created on the next access.
     """
@@ -168,20 +177,21 @@ async def reset_client_async():
             client = None
             logger.info("MongoDB client reset")
 
+
 @with_connection_retry
 async def get_db_async(db_name: str) -> AsyncIOMotorDatabase:
     """
     Get MongoDB database instance asynchronously
-    
+
     Connects to a specific database using the MongoDB client.
     Automatically resets the client on connection errors.
-    
+
     Args:
         db_name: Name of the database to connect to
-        
+
     Returns:
         AsyncIOMotorDatabase: MongoDB database instance
-        
+
     Raises:
         DatabaseException: If getting the database instance fails
     """
@@ -194,17 +204,18 @@ async def get_db_async(db_name: str) -> AsyncIOMotorDatabase:
         message = f"Failed to get database: uri->{MONGODB_URI} db->{db_name}"
         raise DatabaseException(message, logger, e) from e
 
+
 @with_connection_retry
 async def check_db_exists_async(db_name: str) -> bool:
     """
     Check if a database exists asynchronously
-    
+
     Args:
         db_name: Name of the database to check
-        
+
     Returns:
         bool: True if the database exists, False otherwise
-        
+
     Raises:
         DatabaseException: If checking for database existence fails
     """
@@ -216,19 +227,20 @@ async def check_db_exists_async(db_name: str) -> bool:
         message = f"Failed to check if database exists: {db_name}"
         raise DatabaseException(message, logger, e) from e
 
+
 @with_connection_retry
 async def drop_db_async(db_name: str) -> bool:
     """
     Drop a database asynchronously
-    
+
     Completely removes a database and all its collections.
-    
+
     Args:
         db_name: Name of the database to drop
-        
+
     Returns:
         bool: True if the operation was successful
-        
+
     Raises:
         DatabaseException: If dropping the database fails
     """
@@ -241,13 +253,106 @@ async def drop_db_async(db_name: str) -> bool:
         message = f"Failed to drop database: {db_name}"
         raise DatabaseException(message, logger, e) from e
 
+
+# How many colliding key values to name when a unique index cannot be built.
+# Enough to see the shape of the problem; not so many that the message becomes
+# the data dump it is describing.
+BLOCKING_DUPLICATE_SAMPLE = 5
+
+
+async def find_blocking_duplicates_async(
+    db: AsyncIOMotorDatabase,
+    collection_name: str,
+    index_keys: dict,
+    partial_filter_expression: Optional[dict] = None,
+    limit: int = BLOCKING_DUPLICATE_SAMPLE,
+) -> list:
+    """
+    Key values that already appear more than once, and so block a unique index.
+
+    Called when a required unique index turns out to be missing after the attempt
+    to build it. Without this the caller can only say the build failed and guess
+    at why; with it, the failure names the documents that have to be resolved.
+
+    Best-effort by design: an aggregation that fails here must not replace the
+    failure it was called to explain.
+
+    Args:
+        db: Database instance
+        collection_name: Collection the index belongs to
+        index_keys: The index key specification, e.g. {"tenant_id": 1, ...}
+        partial_filter_expression: The index's partial filter, when it has one -
+            documents outside it are not indexed and so cannot be blocking
+        limit: Maximum number of colliding key values to return
+
+    Returns:
+        List of {"_id": {...key values...}, "n": count}, most-duplicated first,
+        or an empty list if nothing was found or the lookup itself failed
+    """
+    try:
+        pipeline = []
+        if partial_filter_expression:
+            pipeline.append({"$match": partial_filter_expression})
+        pipeline += [
+            # A $group _id may not contain dots in its field names, and index
+            # keys can be nested paths.
+            {"$group": {"_id": {k.replace(".", "\uff0e"): f"${k}" for k in index_keys}, "n": {"$sum": 1}}},
+            {"$match": {"n": {"$gt": 1}}},
+            {"$sort": {"n": -1}},
+            {"$limit": limit},
+        ]
+        return await db[collection_name].aggregate(pipeline).to_list(length=limit)
+    except Exception as e:
+        logger.warning(f"Could not identify the documents blocking an index on {collection_name}: {e}")
+        return []
+
+
+async def run_setup_steps_async(tenant_id: str, steps: list) -> None:
+    """
+    Run every setup step, then report all the failures rather than only the first.
+
+    Stopping at the first failure is worse than it looks: the collections after it
+    are never created either, so one blocked collection leaves the rest of the
+    tenant unset up - and the operator learns about the blocked ones one restart
+    at a time. Running them all leaves every healthy collection ready and names
+    every blocked one at once (issue #185).
+
+    A backend that cannot be reached is different in kind and still stops
+    everything: the remaining steps would only fail the same way.
+
+    Args:
+        tenant_id: Passed to each step
+        steps: Setup coroutine functions taking a single tenant_id argument
+
+    Raises:
+        DatabaseException: If any step failed, naming all of them
+        ConnectionFailure / ServerSelectionTimeoutError: propagated immediately
+    """
+    failures = []
+    for step in steps:
+        try:
+            await step(tenant_id)
+        except (ConnectionFailure, ServerSelectionTimeoutError):
+            raise
+        except Exception as e:
+            failures.append(str(e))
+            logger.error(f"Tenant setup step {getattr(step, '__name__', step)} failed: {e}")
+
+    if failures:
+        raise DatabaseException(
+            f"Tenant setup for {tenant_id} could not complete {len(failures)} of {len(steps)} steps: "
+            + " | ".join(failures),
+            logger,
+        )
+
+
 @with_connection_retry
 async def create_collection_with_indexes_async(
-        db_name: str,
-        collection_name: str,
-        index_keys_list: list,
-        index_name: str,
-        drop_indexes_by_keys: list = None,
+    db_name: str,
+    collection_name: str,
+    index_keys_list: list,
+    index_name: str,
+    drop_indexes_by_keys: list = None,
 ):
     """
     Create a collection with specified indexes asynchronously
@@ -323,18 +428,37 @@ async def create_collection_with_indexes_async(
         # by index key pattern (name-agnostic) and hard-fail if it was not achieved.
         # New collections skip this: there is nothing to migrate and a brand-new
         # collection always reflects index_keys_list exactly.
-        if not created:
-            final_info = await db[collection_name].index_information()
-            present = [tuple((k, v) for k, v in info.get("key", [])) for info in final_info.values()]
+        # Verified whether or not the collection was just created. A new
+        # collection is expected to reflect index_keys_list exactly, but the
+        # ensure loop above swallows its failures with a warning - so without
+        # this, an index that never got built reports success (issue #185).
+        final_info = await db[collection_name].index_information()
+        present = [tuple((k, v) for k, v in info.get("key", [])) for info in final_info.values()]
 
-            for index_info in index_keys_list:
-                want = tuple((k, v) for k, v in index_info.get("keys", {}).items())
-                if want not in present:
-                    raise DatabaseException(
-                        f"Required index {want} missing on {collection_name} after migration "
-                        "(index ensure failed — likely existing data violates a new unique constraint)",
-                        logger,
+        for index_info in index_keys_list:
+            keys_dict = index_info.get("keys", {})
+            want = tuple((k, v) for k, v in keys_dict.items())
+            if want not in present:
+                # Say what is actually in the way. "Likely existing data
+                # violates a new unique constraint" was a guess, and left the
+                # operator with a collection name and nothing to act on.
+                blocking = ""
+                if index_info.get("unique"):
+                    duplicates = await find_blocking_duplicates_async(
+                        db, collection_name, keys_dict, index_info.get("partialFilterExpression")
                     )
+                    if duplicates:
+                        listed = "; ".join(f"{d.get('_id')} x{d.get('n')}" for d in duplicates)
+                        blocking = (
+                            f" Documents already in the collection share this key and have to be "
+                            f"resolved before it can be built (showing up to "
+                            f"{BLOCKING_DUPLICATE_SAMPLE}): {listed}"
+                        )
+                raise DatabaseException(
+                    f"Required index {want} missing on {collection_name} after migration "
+                    f"(index ensure failed).{blocking}",
+                    logger,
+                )
 
             if drop_indexes_by_keys:
                 for drop_keys in drop_indexes_by_keys:
@@ -353,6 +477,7 @@ async def create_collection_with_indexes_async(
         message = f"Failed to create collection with indexes: {collection_name} in {db_name}. Error: {str(e)}"
         logger.error(f"Collection with indexes creation error: {type(e).__name__}: {str(e)}")
         raise DatabaseException(message, logger, e) from e
+
 
 async def create_collection_async(collection_name: str, db: AsyncIOMotorDatabase):
     """
@@ -380,7 +505,7 @@ async def create_collection_async(collection_name: str, db: AsyncIOMotorDatabase
     try:
         if collection_name in await db.list_collection_names():
             logger.info(f"Collection {collection_name} already exists")
-            return False # return false if collection already exists
+            return False  # return false if collection already exists
         await db.create_collection(collection_name)
         logger.info(f"Collection {collection_name} created")
     except (ConnectionFailure, ServerSelectionTimeoutError):
@@ -390,6 +515,7 @@ async def create_collection_async(collection_name: str, db: AsyncIOMotorDatabase
         logger.error(f"Collection creation error details: {type(e).__name__}: {str(e)}")
         raise DatabaseException(message, logger, e) from e
     return True
+
 
 async def drop_collection_async(collection_name: str, db: AsyncIOMotorDatabase):
     """
@@ -424,6 +550,7 @@ async def drop_collection_async(collection_name: str, db: AsyncIOMotorDatabase):
         raise DatabaseException(message, logger, e) from e
     return True
 
+
 async def execute_command_async(command: dict, db: AsyncIOMotorDatabase):
     """
     Execute a MongoDB command asynchronously
@@ -454,6 +581,7 @@ async def execute_command_async(command: dict, db: AsyncIOMotorDatabase):
         message = f"Failed to execute command: {command}"
         raise DatabaseException(message, logger, e) from e
     return True
+
 
 def create_indexes_command(
     collection_name: str,
@@ -504,22 +632,20 @@ def create_indexes_command(
 
     indexes.append(index)
 
-    return {
-        "createIndexes": collection_name,
-        "indexes": indexes
-    }
+    return {"createIndexes": collection_name, "indexes": indexes}
+
 
 async def get_collection_async(collection_name: str, db: AsyncIOMotorDatabase):
     """
     Get a MongoDB collection instance asynchronously
-    
+
     Args:
         collection_name: Name of the collection to retrieve
         db: Database instance
-        
+
     Returns:
         AsyncIOMotorCollection: Collection instance
-        
+
     Raises:
         DatabaseException: If getting the collection fails
     """
@@ -529,16 +655,17 @@ async def get_collection_async(collection_name: str, db: AsyncIOMotorDatabase):
         message = f"Failed to get collection: {collection_name}"
         raise DatabaseException(message, logger, e) from e
 
+
 async def get_collection_names_async(db: AsyncIOMotorDatabase):
     """
     Get a list of collection names in a database asynchronously
-    
+
     Args:
         db: Database instance
-        
+
     Returns:
         list: List of collection names
-        
+
     Raises:
         DatabaseException: If getting the collection names fails
     """

--- a/services/commons/src/kugel_common/database/database.py
+++ b/services/commons/src/kugel_common/database/database.py
@@ -259,6 +259,12 @@ async def drop_db_async(db_name: str) -> bool:
 # the data dump it is describing.
 BLOCKING_DUPLICATE_SAMPLE = 5
 
+# Ceiling on the diagnostic aggregation. It runs on a collection with no usable
+# index for the grouping - a full scan - and the collection it runs on is a
+# production log that may hold millions of documents. Better to return a failure
+# without the sample than to spend the database on explaining one.
+BLOCKING_DUPLICATE_TIMEOUT_MS = 10_000
+
 
 async def find_blocking_duplicates_async(
     db: AsyncIOMotorDatabase,
@@ -275,7 +281,13 @@ async def find_blocking_duplicates_async(
     at why; with it, the failure names the documents that have to be resolved.
 
     Best-effort by design: an aggregation that fails here must not replace the
-    failure it was called to explain.
+    failure it was called to explain - including when it exceeds
+    BLOCKING_DUPLICATE_TIMEOUT_MS on a collection too large to scan.
+
+    Does not resolve a unique index on an array field: `$group` groups on the
+    array as a value, while the index collides on the elements, so `[1, 2]` and
+    `[2, 3]` read as distinct here and clash in the index. No unique index in
+    this system is on an array field; if one is added, this needs `$unwind`.
 
     Args:
         db: Database instance
@@ -301,7 +313,12 @@ async def find_blocking_duplicates_async(
             {"$sort": {"n": -1}},
             {"$limit": limit},
         ]
-        return await db[collection_name].aggregate(pipeline).to_list(length=limit)
+        cursor = db[collection_name].aggregate(
+            pipeline,
+            allowDiskUse=True,
+            maxTimeMS=BLOCKING_DUPLICATE_TIMEOUT_MS,
+        )
+        return await cursor.to_list(length=limit)
     except Exception as e:
         logger.warning(f"Could not identify the documents blocking an index on {collection_name}: {e}")
         return []
@@ -433,11 +450,40 @@ async def create_collection_with_indexes_async(
         # ensure loop above swallows its failures with a warning - so without
         # this, an index that never got built reports success (issue #185).
         final_info = await db[collection_name].index_information()
-        present = [tuple((k, v) for k, v in info.get("key", [])) for info in final_info.values()]
+        # Grouped, not keyed: MongoDB lets a unique and a non-unique index share
+        # a key pattern under different names, so collapsing them into a dict
+        # keeps whichever came last and makes the check below order-dependent.
+        by_keys = {}
+        for info in final_info.values():
+            by_keys.setdefault(tuple((k, v) for k, v in info.get("key", [])), []).append(info)
+        present = list(by_keys)
 
         for index_info in index_keys_list:
             keys_dict = index_info.get("keys", {})
             want = tuple((k, v) for k, v in keys_dict.items())
+
+            # An index with the right keys but the wrong options is the same
+            # failure wearing a disguise: createIndexes refuses to change them
+            # (IndexOptionsConflict), the ensure loop above logs a warning, and a
+            # keys-only check then reports success over a constraint that is not
+            # being enforced.
+            if want in present and index_info.get("unique") and not any(i.get("unique") for i in by_keys[want]):
+                # The keys are there and the uniqueness is not. Left to the check
+                # below, this reads as satisfied - a constraint the system relies
+                # on, reported as present while nothing enforces it.
+                blocking = ""
+                duplicates = await find_blocking_duplicates_async(
+                    db, collection_name, keys_dict, index_info.get("partialFilterExpression")
+                )
+                if duplicates:
+                    listed = "; ".join(f"{d.get('_id')} x{d.get('n')}" for d in duplicates)
+                    blocking = f" Documents sharing this key (showing up to {BLOCKING_DUPLICATE_SAMPLE}): {listed}"
+                raise DatabaseException(
+                    f"Index {want} on {collection_name} exists but no index on those keys is unique, "
+                    f"so the uniqueness relied on here is not enforced.{blocking}",
+                    logger,
+                )
+
             if want not in present:
                 # Say what is actually in the way. "Likely existing data
                 # violates a new unique constraint" was a guess, and left the

--- a/services/commons/tests/unit/test_setup_steps.py
+++ b/services/commons/tests/unit/test_setup_steps.py
@@ -1,0 +1,96 @@
+# Copyright 2026 masa@kugel
+"""Running the tenant setup steps (issue #185).
+
+Stopping at the first failing collection is worse than it looks: the collections
+after it are never created either, so one blocked collection leaves the rest of
+the tenant unset up — and the operator learns about the blocked ones one restart
+at a time.
+
+What these pin is that every step is attempted, that a failure names all of them,
+and that an unreachable backend is still treated as different in kind.
+"""
+
+import pytest
+from pymongo.errors import ServerSelectionTimeoutError
+
+from kugel_common.database.database import run_setup_steps_async
+from kugel_common.database.database_exceptions import DatabaseException
+
+pytestmark = pytest.mark.asyncio
+
+
+def _step(name, fails_with=None, ran=None):
+    async def step(tenant_id):
+        if ran is not None:
+            ran.append(name)
+        if fails_with is not None:
+            raise fails_with
+
+    step.__name__ = name
+    return step
+
+
+class TestEveryStepIsAttempted:
+    async def test_a_failing_step_does_not_stop_the_ones_after_it(self):
+        ran = []
+        steps = [
+            _step("first", ran=ran),
+            _step("blocked", RuntimeError("index cannot be built on log_tran"), ran=ran),
+            _step("third", ran=ran),
+            _step("fourth", ran=ran),
+        ]
+
+        with pytest.raises(DatabaseException):
+            await run_setup_steps_async("T0001", steps)
+
+        assert ran == ["first", "blocked", "third", "fourth"], (
+            "a blocked collection stopped the healthy ones from being created"
+        )
+
+    async def test_all_the_failures_are_named_at_once(self):
+        steps = [
+            _step("ok"),
+            _step("a", RuntimeError("log_tran: duplicate transaction_no 1 x4")),
+            _step("b", RuntimeError("log_open_close: duplicate open_counter 1")),
+        ]
+
+        with pytest.raises(DatabaseException) as caught:
+            await run_setup_steps_async("T0001", steps)
+
+        message = str(caught.value)
+        assert "log_tran" in message
+        assert "log_open_close" in message, "only the first failure was reported"
+        assert "2 of 3" in message
+
+    async def test_nothing_is_raised_when_every_step_succeeds(self):
+        ran = []
+        await run_setup_steps_async("T0001", [_step("a", ran=ran), _step("b", ran=ran)])
+
+        assert ran == ["a", "b"]
+
+    async def test_the_tenant_reaches_every_step(self):
+        seen = []
+
+        async def step(tenant_id):
+            seen.append(tenant_id)
+
+        await run_setup_steps_async("T6216", [step, step])
+
+        assert seen == ["T6216", "T6216"]
+
+
+class TestAnUnreachableBackendIsDifferent:
+    async def test_it_stops_immediately_rather_than_failing_every_step(self):
+        # The remaining steps could only fail the same way, and a list of
+        # identical connection errors describes nothing the first one did not.
+        ran = []
+        steps = [
+            _step("first", ran=ran),
+            _step("down", ServerSelectionTimeoutError("backend unreachable"), ran=ran),
+            _step("never", ran=ran),
+        ]
+
+        with pytest.raises(ServerSelectionTimeoutError):
+            await run_setup_steps_async("T0001", steps)
+
+        assert ran == ["first", "down"], "setup carried on against an unreachable backend"

--- a/services/journal/Pipfile
+++ b/services/journal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 
 httpx = "*"
 aiohttp = "*"

--- a/services/journal/Pipfile.lock
+++ b/services/journal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b6c0f26a92b4e13427d7f1bbeb926474fae1392f8766d39365de0ff6c5756f4"
+            "sha256": "3c385c27f05866e2a24b543fbba6abf1ad82c59995a9794d0bd04b1860cb72dd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -544,9 +544,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/journal/app/api/v1/tenant.py
+++ b/services/journal/app/api/v1/tenant.py
@@ -41,7 +41,11 @@ async def create_tenant(
         await database_setup.execute(tenant_id=tenant_id)
 
     except Exception as e:
-        message = f"Error creating tenant: {tenant_id}"
+        # Carry the reason, not just the tenant. Which collection and which index
+        # could not be built - and, for a unique index, the documents in the way -
+        # already exist one frame down; discarding them left an operator with a
+        # bare 500 and nowhere to start (issue #185).
+        message = f"Error creating tenant: {tenant_id}: {e}"
         logger.error(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message)
 

--- a/services/journal/app/database/database_setup.py
+++ b/services/journal/app/database/database_setup.py
@@ -135,13 +135,22 @@ async def create_request_log_collection(tenant_id: str):
 
 # create all collections
 async def create_collections(tenant_id: str):
-    await create_tran_collection(tenant_id)
-    await create_cash_in_out_log_collection(tenant_id)
-    await create_open_close_log_collection(tenant_id)
-    await create_journal_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
+    """Create every collection this service needs for a tenant.
 
-    # add more collections here
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
+    """
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_tran_collection,
+            create_cash_in_out_log_collection,
+            create_open_close_log_collection,
+            create_journal_collection,
+            create_request_log_collection,
+        ],
+    )
 
 
 # setup database

--- a/services/journal/tests/e2e/test_tenant_setup_report.py
+++ b/services/journal/tests/e2e/test_tenant_setup_report.py
@@ -1,0 +1,112 @@
+# Copyright 2026 masa@kugel
+"""What tenant setup tells an operator when it cannot finish (issue #185).
+
+Collections are created before their indexes, so anything already written has to
+satisfy them. When it does not, the index can never be built and setup fails on
+every retry — and what came back was `Error creating tenant: T6216` and nothing
+else. The collection, the index and the documents in the way all existed one
+frame down and were discarded.
+
+Observed on real data here: after repeated e2e runs dropped the tenant database
+while cart kept publishing, this journal held transaction 1 four times.
+
+End-to-end because the failing response is the deliverable. Each test restores
+the tenant database before it finishes — leaving a blocked collection behind
+would block every later run, which is the whole point of the issue.
+"""
+
+import os
+
+import pytest
+from fastapi import status
+from motor.motor_asyncio import AsyncIOMotorClient
+
+pytestmark = pytest.mark.asyncio
+
+DUPLICATE = {
+    "tenant_id": None,  # filled per test
+    "store_code": "9185",
+    "terminal_no": 5,
+    "business_date": "20260822",
+    "open_counter": 7,
+    "operation": "open",
+}
+
+
+def _client():
+    return AsyncIOMotorClient(os.environ.get("MONGODB_URI"))
+
+
+def _db_name():
+    return f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}"
+
+
+async def _block_a_collection(copies=3):
+    """Reproduce the window the issue is about.
+
+    The unique index is dropped first, then the duplicates are written - which is
+    the order it happens for real: the tenant database is dropped or has never
+    been created, deliveries arrive with no index to refuse them, and setup then
+    tries to build one over data that cannot satisfy it.
+    """
+    collection = _client()[_db_name()]["log_open_close"]
+    for name, info in (await collection.index_information()).items():
+        if name != "_id_" and info.get("unique"):
+            await collection.drop_index(name)
+    doc = dict(DUPLICATE, tenant_id=os.environ.get("TENANT_ID"))
+    await collection.insert_many([dict(doc) for _ in range(copies)])
+
+
+async def _unblock():
+    """Resolve the duplicates, the way an operator would.
+
+    The index itself is rebuilt by the next successful setup - which is exactly
+    what the last test asserts.
+    """
+    await _client()[_db_name()]["log_open_close"].delete_many({"store_code": DUPLICATE["store_code"]})
+
+
+async def test_the_failure_names_the_collection_and_the_documents(http_client, admin_header):
+    tenant_id = os.environ.get("TENANT_ID")
+    await _block_a_collection()
+    try:
+        response = await http_client.post("/api/v1/tenants", json={"tenant_id": tenant_id}, headers=admin_header)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        detail = response.text
+        assert "log_open_close" in detail, f"the response did not name the collection: {detail[:300]}"
+        assert "open_counter" in detail, "the response did not name the index"
+        assert "x3" in detail, f"the response did not say what is in the way: {detail[:300]}"
+    finally:
+        await _unblock()
+
+
+async def test_the_collections_that_can_be_set_up_still_are(http_client, admin_header):
+    """One blocked collection used to stop every collection after it."""
+    tenant_id = os.environ.get("TENANT_ID")
+    db = _client()[_db_name()]
+    await db["log_tran"].drop()
+    await _block_a_collection()
+    try:
+        response = await http_client.post("/api/v1/tenants", json={"tenant_id": tenant_id}, headers=admin_header)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "1 of" in response.text, f"expected exactly one blocked step: {response.text[:300]}"
+
+        names = await db.list_collection_names()
+        assert "log_tran" in names, "a blocked collection stopped the healthy ones from being created"
+        indexes = await db["log_tran"].index_information()
+        assert len(indexes) > 1, "the healthy collection was created without its indexes"
+    finally:
+        await _unblock()
+
+
+async def test_setup_succeeds_once_the_documents_are_resolved(http_client, admin_header):
+    tenant_id = os.environ.get("TENANT_ID")
+    await _block_a_collection()
+    response = await http_client.post("/api/v1/tenants", json={"tenant_id": tenant_id}, headers=admin_header)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    await _unblock()
+
+    response = await http_client.post("/api/v1/tenants", json={"tenant_id": tenant_id}, headers=admin_header)
+    assert response.status_code in (status.HTTP_201_CREATED, status.HTTP_400_BAD_REQUEST), response.text

--- a/services/master-data/Pipfile
+++ b/services/master-data/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 httpx = "*"
 wcwidth = "*"
 debugpy = "*"

--- a/services/master-data/Pipfile.lock
+++ b/services/master-data/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8de8aac0b8985c0a175dd38b1e784a464867fa6350f371b77dd7a75512ad7107"
+            "sha256": "cc016c9a546aed6e1480a78d0e6c838dcc0e4395d1e4fce74b3def9da984a04d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -258,9 +258,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/master-data/app/api/v1/tenant.py
+++ b/services/master-data/app/api/v1/tenant.py
@@ -38,7 +38,11 @@ async def create_tenant(req: TenantCreateRequest, tenant_id: str = Depends(get_t
         await database_setup.execute(tenant_id=tenant_id)
 
     except Exception as e:
-        message = f"Error creating tenant: {tenant_id}"
+        # Carry the reason, not just the tenant. Which collection and which index
+        # could not be built - and, for a unique index, the documents in the way -
+        # already exist one frame down; discarding them left an operator with a
+        # bare 500 and nowhere to start (issue #185).
+        message = f"Error creating tenant: {tenant_id}: {e}"
         logger.error(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message)
 

--- a/services/master-data/app/database/database_setup.py
+++ b/services/master-data/app/database/database_setup.py
@@ -123,17 +123,26 @@ async def create_request_log_collection(tenant_id: str):
 
 # create all collections
 async def create_collections(tenant_id: str):
-    await create_master_item_collection(tenant_id)
-    await create_master_item_store_collection(tenant_id)
-    await create_master_item_book_collection(tenant_id)
-    await create_master_category_collection(tenant_id)
-    await create_master_payment_collection(tenant_id)
-    await create_master_settings_collection(tenant_id)
-    await create_master_staff_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
-    await create_master_promotion_collection(tenant_id)
+    """Create every collection this service needs for a tenant.
 
-    # add more collections here
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
+    """
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_master_item_collection,
+            create_master_item_store_collection,
+            create_master_item_book_collection,
+            create_master_category_collection,
+            create_master_payment_collection,
+            create_master_settings_collection,
+            create_master_staff_collection,
+            create_request_log_collection,
+            create_master_promotion_collection,
+        ],
+    )
 
 
 # Settings a POS terminal must be able to read, seeded so the documented lookup

--- a/services/report/Pipfile
+++ b/services/report/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/report/Pipfile.lock
+++ b/services/report/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6ca845f408c8b4c1d252c6b1273fed3109f8f43ba602b3b80056b0c9e9cccd1b"
+            "sha256": "8a8cb8965d6e10bc594d32783b304623da3d06de3a1f91a269b5d0e063661be4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -722,9 +722,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/report/app/database/database_setup.py
+++ b/services/report/app/database/database_setup.py
@@ -111,12 +111,21 @@ async def create_request_log_collection(tenant_id: str):
 
 # create all collections
 async def create_collections(tenant_id: str):
-    await create_tran_collection(tenant_id)
-    await create_cash_in_out_log_collection(tenant_id)
-    await create_open_close_log_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
+    """Create every collection this service needs for a tenant.
 
-    # add more collections here
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
+    """
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_tran_collection,
+            create_cash_in_out_log_collection,
+            create_open_close_log_collection,
+            create_request_log_collection,
+        ],
+    )
 
 
 # setup database

--- a/services/stock/Pipfile
+++ b/services/stock/Pipfile
@@ -14,7 +14,7 @@ pytz = "*"
 pyjwt = "*"
 httpx = "*"
 aiohttp = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 wcwidth = "*"
 debugpy = "*"
 requests = "*"

--- a/services/stock/Pipfile.lock
+++ b/services/stock/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a52afdfb1cb6d9e5ed8cca3abcc57e532f24467bee41a798fbf05e975a6f4fbb"
+            "sha256": "3da3bcb8615dcc21b8c4de0cd1593a20134ed617e736cdc47e3b6583114991a9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -731,9 +731,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/stock/app/database/database_setup.py
+++ b/services/stock/app/database/database_setup.py
@@ -106,12 +106,21 @@ async def create_request_log_collection(tenant_id: str):
 
 # create all collections
 async def create_collections(tenant_id: str):
-    await create_stock_collection(tenant_id)
-    await create_stock_update_collection(tenant_id)
-    await create_stock_snapshot_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
+    """Create every collection this service needs for a tenant.
 
-    # add more collections here
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
+    """
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_stock_collection,
+            create_stock_update_collection,
+            create_stock_snapshot_collection,
+            create_request_log_collection,
+        ],
+    )
 
 
 # setup database

--- a/services/terminal/Pipfile
+++ b/services/terminal/Pipfile
@@ -12,7 +12,7 @@ pydantic-settings = "*"
 motor = "*"
 pytz = "*"
 pyjwt = "*"
-kugel_common = {file = "commons/dist/kugel_common-0.1.75-py3-none-any.whl"}
+kugel_common = {file = "commons/dist/kugel_common-0.1.76-py3-none-any.whl"}
 httpx = "*"
 aiohttp = "*"
 wcwidth = "*"

--- a/services/terminal/Pipfile.lock
+++ b/services/terminal/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a7f6b747d07d9f58f8bb14eeaf1540c7cf3c60fe3d483946f5586f54a1f5797e"
+            "sha256": "aa3192aa54be2f19e7d8774c0a57e57ffc4b79d9c98af740619de7a83a179e56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -553,9 +553,9 @@
             "version": "==3.19"
         },
         "kugel-common": {
-            "file": "commons/dist/kugel_common-0.1.75-py3-none-any.whl",
+            "file": "commons/dist/kugel_common-0.1.76-py3-none-any.whl",
             "hashes": [
-                "sha256:356e3ea3732e5c7ddb2f254a2b999a2f9ddcd71548126b7e853a85ad7e1bb980"
+                "sha256:480292c99322b0fe4bcb9eda5332aad2de09c29a58c19dddfc4b36b1e7d1797a"
             ]
         },
         "motor": {

--- a/services/terminal/app/api/v1/tenant.py
+++ b/services/terminal/app/api/v1/tenant.py
@@ -27,6 +27,11 @@ from app.dependencies.get_tenant_service import (
     get_tenant_id_with_security_by_query_optional_wrapper,
 )
 
+# How much of a downstream error body to carry into the response. Enough for the
+# collection and index a service names when tenant setup fails (issue #185),
+# bounded because a proxy in between answers with a whole HTML page.
+DOWNSTREAM_ERROR_CHARS = 1000
+
 router = APIRouter()
 logger = getLogger(__name__)
 audit_logger = getLogger("audit")
@@ -96,9 +101,16 @@ async def create_tenant(
                     # the body, which is where the downstream service says which
                     # collection and index it could not build (issue #185). This
                     # is the fan-out point an operator reaches first.
+                    #
+                    # Truncated: what answers is not always one of our services
+                    # saying something short - a proxy in between can return an
+                    # HTML error page, and that would arrive whole.
+                    downstream = response.text[:DOWNSTREAM_ERROR_CHARS]
+                    if len(response.text) > DOWNSTREAM_ERROR_CHARS:
+                        downstream += f"... ({len(response.text)} chars, truncated)"
                     raise HTTPException(
                         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail=f"Tenant setup failed at {url} ({response.status_code}): {response.text}",
+                        detail=f"Tenant setup failed at {url} ({response.status_code}): {downstream}",
                     )
     except Exception as e:
         raise e
@@ -337,9 +349,7 @@ async def add_store(
     except Exception as e:
         raise e
 
-    audit_logger.info(
-        "Store created (tenant_id=%s, store_code=%s)", tenant_id, store.store_code
-    )
+    audit_logger.info("Store created (tenant_id=%s, store_code=%s)", tenant_id, store.store_code)
 
     response = ApiResponse(
         success=True,
@@ -585,9 +595,7 @@ async def delete_store(
     except Exception as e:
         raise e
 
-    audit_logger.info(
-        "Store deleted (tenant_id=%s, store_code=%s)", tenant_id, store_code
-    )
+    audit_logger.info("Store deleted (tenant_id=%s, store_code=%s)", tenant_id, store_code)
 
     response = ApiResponse(
         success=True,

--- a/services/terminal/app/api/v1/tenant.py
+++ b/services/terminal/app/api/v1/tenant.py
@@ -91,7 +91,15 @@ async def create_tenant(
                 response = await client.post(
                     url, headers={"Authorization": f"Bearer {token}"}, json={"tenant_id": tenant_id}
                 )
-                response.raise_for_status()
+                if response.is_error:
+                    # raise_for_status() reports the URL and the status and drops
+                    # the body, which is where the downstream service says which
+                    # collection and index it could not build (issue #185). This
+                    # is the fan-out point an operator reaches first.
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail=f"Tenant setup failed at {url} ({response.status_code}): {response.text}",
+                    )
     except Exception as e:
         raise e
 

--- a/services/terminal/app/database/database_setup.py
+++ b/services/terminal/app/database/database_setup.py
@@ -176,22 +176,23 @@ async def create_terminallog_delivery_status_collection(tenant_id: str):
 
 
 async def create_collections(tenant_id: str):
-    """
-    Creates all required collections for a tenant
+    """Create every collection this service needs for a tenant.
 
-    This function orchestrates the creation of all necessary MongoDB collections
-    for a new tenant in the system
-
-    Args:
-        tenant_id: Tenant ID to create collections for
+    Through run_setup_steps_async so that one blocked collection does not stop
+    the rest from being created, and so a failure names every blocked collection
+    at once rather than one restart at a time (issue #185).
     """
-    await create_tenant_info_collection(tenant_id)
-    await create_terminal_info_collection(tenant_id)
-    await create_cash_in_out_log_collection(tenant_id)
-    await create_request_log_collection(tenant_id)
-    await create_open_close_log_collection(tenant_id)
-    await create_terminallog_delivery_status_collection(tenant_id)
-    # Additional collections can be added here as needed
+    await db_helper.run_setup_steps_async(
+        tenant_id,
+        [
+            create_tenant_info_collection,
+            create_terminal_info_collection,
+            create_cash_in_out_log_collection,
+            create_request_log_collection,
+            create_open_close_log_collection,
+            create_terminallog_delivery_status_collection,
+        ],
+    )
 
 
 async def execute(tenant_id: str):

--- a/services/terminal/tests/unit/test_api_tenants.py
+++ b/services/terminal/tests/unit/test_api_tenants.py
@@ -83,6 +83,11 @@ class TestCreateTenant:
             mock_client_instance = AsyncMock()
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
+            # A downstream setup that succeeded. Checked rather than
+            # raise_for_status()'d so the failing body survives into the message
+            # (issue #185), and a bare MagicMock is truthy for is_error.
+            mock_response.is_error = False
+            mock_response.status_code = 201
             mock_client_instance.post.return_value = mock_response
             mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -96,6 +101,43 @@ class TestCreateTenant:
         body = resp.json()
         assert body["success"] is True
         assert body["data"]["tenantId"] == TENANT_ID
+
+    @pytest.mark.asyncio
+    async def test_a_downstream_failure_reports_what_that_service_said(self):
+        """The fan-out is where an operator meets the failure first (issue #185).
+
+        `raise_for_status()` reports the URL and the status and drops the body -
+        and the body is where the downstream service names the collection and the
+        index it could not build. Without it the caller is told only that some
+        service returned 500.
+        """
+        app = make_app()
+        mock_service = AsyncMock()
+        with (
+            patch("app.api.v1.tenant.database_setup") as mock_db_setup,
+            patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service),
+            patch("app.api.v1.tenant.httpx.AsyncClient") as mock_httpx,
+        ):
+            mock_db_setup.execute = AsyncMock()
+            mock_client_instance = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.is_error = True
+            mock_response.status_code = 500
+            mock_response.text = "Required index (('tenant_id', 1), ('transaction_no', 1)) missing on log_tran"
+            mock_client_instance.post.return_value = mock_response
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v1/tenants",
+                    json={"tenant_id": TENANT_ID, "tenant_name": "Test Tenant", "tags": ["test"]},
+                )
+
+        assert resp.status_code == 500
+        detail = resp.text
+        assert "log_tran" in detail, f"the downstream reason was dropped: {detail[:200]}"
+        assert "tenants" in detail, "the response did not say which service failed"
 
     @pytest.mark.asyncio
     async def test_tenant_id_mismatch(self):
@@ -124,6 +166,11 @@ class TestCreateTenant:
             mock_client_instance = AsyncMock()
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
+            # A downstream setup that succeeded. Checked rather than
+            # raise_for_status()'d so the failing body survives into the message
+            # (issue #185), and a bare MagicMock is truthy for is_error.
+            mock_response.is_error = False
+            mock_response.status_code = 201
             mock_client_instance.post.return_value = mock_response
             mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -165,9 +212,7 @@ class TestGetTenant:
     async def test_service_error(self):
         app = make_app()
         mock_service = AsyncMock()
-        mock_service.get_tenant_async.side_effect = HTTPException(
-            status_code=404, detail="Not found"
-        )
+        mock_service.get_tenant_async.side_effect = HTTPException(status_code=404, detail="Not found")
 
         with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -232,9 +277,7 @@ class TestDeleteTenant:
     async def test_service_error(self):
         app = make_app()
         mock_service = AsyncMock()
-        mock_service.delete_tenant_async.side_effect = HTTPException(
-            status_code=404, detail="Not found"
-        )
+        mock_service.delete_tenant_async.side_effect = HTTPException(status_code=404, detail="Not found")
 
         with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -248,8 +291,10 @@ class TestDeleteTenant:
         mock_service = AsyncMock()
         mock_service.delete_tenant_async.return_value = None
 
-        with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service), \
-             patch("app.api.v1.tenant.audit_logger") as mock_audit:
+        with (
+            patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service),
+            patch("app.api.v1.tenant.audit_logger") as mock_audit,
+        ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.delete(f"/api/v1/tenants/{TENANT_ID}")
         assert resp.status_code == 200
@@ -290,9 +335,7 @@ class TestAddStore:
     async def test_service_error(self):
         app = make_app()
         mock_service = AsyncMock()
-        mock_service.add_store_async.side_effect = HTTPException(
-            status_code=400, detail="Duplicate store"
-        )
+        mock_service.add_store_async.side_effect = HTTPException(status_code=400, detail="Duplicate store")
 
         with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -354,9 +397,7 @@ class TestGetStore:
     async def test_service_error(self):
         app = make_app()
         mock_service = AsyncMock()
-        mock_service.get_store_async.side_effect = HTTPException(
-            status_code=404, detail="Store not found"
-        )
+        mock_service.get_store_async.side_effect = HTTPException(status_code=404, detail="Store not found")
 
         with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -421,9 +462,7 @@ class TestDeleteStore:
     async def test_service_error(self):
         app = make_app()
         mock_service = AsyncMock()
-        mock_service.delete_store_async.side_effect = HTTPException(
-            status_code=404, detail="Store not found"
-        )
+        mock_service.delete_store_async.side_effect = HTTPException(status_code=404, detail="Store not found")
 
         with patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/services/terminal/tests/unit/test_api_tenants.py
+++ b/services/terminal/tests/unit/test_api_tenants.py
@@ -140,6 +140,42 @@ class TestCreateTenant:
         assert "tenants" in detail, "the response did not say which service failed"
 
     @pytest.mark.asyncio
+    async def test_a_downstream_error_page_is_truncated(self):
+        """What answers is not always one of our services saying something short.
+
+        A proxy in between returns a whole HTML page, and that would otherwise
+        arrive intact in the response.
+        """
+        from app.api.v1.tenant import DOWNSTREAM_ERROR_CHARS
+
+        app = make_app()
+        mock_service = AsyncMock()
+        with (
+            patch("app.api.v1.tenant.database_setup") as mock_db_setup,
+            patch("app.api.v1.tenant.get_tenant_service_async", return_value=mock_service),
+            patch("app.api.v1.tenant.httpx.AsyncClient") as mock_httpx,
+        ):
+            mock_db_setup.execute = AsyncMock()
+            mock_client_instance = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.is_error = True
+            mock_response.status_code = 502
+            mock_response.text = "<html>" + ("x" * 50_000) + "</html>"
+            mock_client_instance.post.return_value = mock_response
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v1/tenants",
+                    json={"tenant_id": TENANT_ID, "tenant_name": "Test Tenant", "tags": ["test"]},
+                )
+
+        assert resp.status_code == 500
+        assert len(resp.text) < DOWNSTREAM_ERROR_CHARS * 3, f"the whole page was echoed ({len(resp.text)} chars)"
+        assert "truncated" in resp.text, "the response did not say it had been cut"
+
+    @pytest.mark.asyncio
     async def test_tenant_id_mismatch(self):
         app = make_app()
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:


### PR DESCRIPTION
Refs #185.

## The defect

A tenant setup that hit a collection whose unique index could not be built returned this and nothing else:

```
{"success":false,"code":500,"message":"Error creating tenant: T6216", ...}
```

No collection, no index, no reason — and the same 500 on every retry. Everything needed to act on it existed one frame down and was discarded.

Observed on real data during this work: a journal held **transaction 1 four times**, so `log_tran`'s unique index could never be rebuilt.

## Three changes, one gap

**Name the documents that are in the way.** The message said the index was *"likely"* blocked by existing data. Now it looks:

```
Required index (('tenant_id', 1), ('store_code', 1), ('terminal_no', 1),
('business_date', 1), ('open_counter', 1), ('operation', 1)) missing on
log_open_close after migration (index ensure failed). Documents already in the
collection share this key and have to be resolved before it can be built
(showing up to 5): {'tenant_id': 'T6216', ..., 'open_counter': 7,
'operation': 'open'} x3
```

`find_blocking_duplicates_async` honours a partial filter — documents outside it are not indexed and so cannot be what stops the build; naming them would send an operator after the wrong rows. It is best-effort: an aggregation that fails must not replace the failure it was called to explain.

**Finish the collections that can be finished.** `create_collections` stopped at the first failure, so one blocked collection also left every collection *after* it uncreated — and the operator learned about the blocked ones one restart at a time. All seven services now run their steps through `run_setup_steps_async`, which attempts every step and reports all the failures at once. An unreachable backend is still different in kind and stops immediately, since the remaining steps could only fail the same way.

**Carry the reason into the response.** The tenant endpoints discarded it, and terminal's fan-out used `raise_for_status()` — which reports the URL and the status and drops the body, the body being where the downstream service names the collection. That fan-out is the point an operator meets first; it is what produced the original `Server error '500 Internal Server Error' for url 'http://journal:8000/api/v1/tenants'`.

**Also**: the end-state is now verified on newly created collections, not only migrated ones. The ensure loop swallows its failures with a warning, so an index that never got built on a new collection reported success.

## Verified on the running stack

Three duplicate open/close events, then `POST /tenants`:

```
HTTP 500
names the collection : True
names the duplicates : True
names the key values : True

500: Error creating tenant: T6216: Tenant setup for T6216 could not complete
1 of 5 steps: Failed to create collection with indexes: log_open_close in ...
```

Note `1 of 5` — the other four collections were set up.

| mutation | tests that fail |
|---|---|
| do not name the blocking documents | e2e + integration |
| stop at the first failing step | e2e + unit |

Both run against the **running container**, not the source tree, since an e2e that cannot fail is worth nothing.

commons unit 581 · every service's unit suite · all integration · all e2e — green. `kugel_common` bumped to 0.1.76.

## Not addressed, and left on the issue

**How the duplicates get in.** The repositories guard with a check-then-act that is only safe while the unique index exists — and the window this issue is about is precisely when it does not. Two at-least-once deliveries can both pass the check and both insert. Closing that is a change to the write paths across services, and a different piece of work from making the failure legible.

So this PR makes a blocked tenant diagnosable and repairable; it does not stop a tenant becoming blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB
