### PR TITLE
fix: key the request-log index on the fields a request log actually has (#182)

### DIFF
--- a/services/account/app/database/database_setup.py
+++ b/services/account/app/database/database_setup.py
@@ -19,7 +19,9 @@ from app.config.settings import settings
 logger = getLogger(__name__)
 
 
-async def create_some_collection(tenant_id: str, collection_name: str, index_keys_list: list, index_name: str):
+async def create_some_collection(
+    tenant_id: str, collection_name: str, index_keys_list: list, index_name: str, drop_indexes_by_keys: list = None
+):
     """
     Create a collection with specified indexes in the tenant's database
 
@@ -28,13 +30,20 @@ async def create_some_collection(tenant_id: str, collection_name: str, index_key
         collection_name: Name of the collection to create
         index_keys_list: List of index configurations to create on the collection
         index_name: Base name for the indexes
+        drop_indexes_by_keys: Index key patterns to retire first, matched by
+            pattern rather than by name (issue #182 uses it to replace the
+            index keyed on fields a request log document does not have)
 
     Returns:
         None
     """
     db_name = f"{settings.DB_NAME_PREFIX}_{tenant_id}"
     await db_helper.create_collection_with_indexes_async(
-        db_name=db_name, collection_name=collection_name, index_keys_list=index_keys_list, index_name=index_name
+        db_name=db_name,
+        collection_name=collection_name,
+        index_keys_list=index_keys_list,
+        index_name=index_name,
+        drop_indexes_by_keys=drop_indexes_by_keys,
     )
 
 
@@ -62,8 +71,9 @@ async def create_request_log_collection(tenant_id: str):
     """
     Create the request log collection with appropriate indexes
 
-    Creates a collection for storing API request logs with a compound index
-    on tenant_id, store_code, terminal_no, and request acceptance time.
+    Creates a collection for storing API request logs, indexed by tenant,
+    store, terminal and request acceptance time (issue #182: by the paths those
+    last two actually live at, and no longer unique).
 
     Args:
         tenant_id: The tenant identifier
@@ -73,10 +83,36 @@ async def create_request_log_collection(tenant_id: str):
     """
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/account/tests/unit/test_database_setup.py
+++ b/services/account/tests/unit/test_database_setup.py
@@ -45,6 +45,7 @@ async def test_create_some_collection(mock_db_helper):
         collection_name=collection_name,
         index_keys_list=index_keys_list,
         index_name=index_name,
+        drop_indexes_by_keys=None,
     )
 
 
@@ -78,8 +79,21 @@ async def test_create_request_log_collection(mock_create_some):
     await create_request_log_collection(tenant_id=TENANT_ID)
 
     expected_name = settings.DB_COLLECTION_NAME_REQUEST_LOG
+    # Issue #182: keyed on the paths a request log document actually has -
+    # `store_code` and `terminal_no` live under `terminal_info`, so at the top
+    # level they indexed as null and the constraint was one request per tenant
+    # per timestamp. No longer unique either: an audit trail should not be the
+    # thing that decides a record did not happen.
     expected_index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
 
     mock_create_some.assert_awaited_once_with(
@@ -87,6 +101,7 @@ async def test_create_request_log_collection(mock_create_some):
         collection_name=expected_name,
         index_keys_list=expected_index_key_list,
         index_name=expected_name + "_index",
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/cart/app/database/database_setup.py
+++ b/services/cart/app/database/database_setup.py
@@ -149,8 +149,9 @@ async def create_request_log_collection(tenant_id: str):
     """
     Creates the request log collection with a compound index.
 
-    This collection stores API request logs and is indexed by tenant,
-    store, terminal and request acceptance time.
+    This collection stores API request logs, indexed by tenant, store,
+    terminal and request acceptance time (issue #182: by the paths those last
+    two actually live at, and no longer unique).
 
     Args:
         tenant_id: The tenant identifier used to create the database name
@@ -160,7 +161,28 @@ async def create_request_log_collection(tenant_id: str):
     """
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True},
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        },
         # Rollback detection (issue #165): walk a cart's revisions in the order
         # they were presented. Normal operation is strictly increasing and a
         # retry repeats a value; anything lower is a replayed older envelope.
@@ -172,7 +194,12 @@ async def create_request_log_collection(tenant_id: str):
         },
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/cart/tests/integration/test_request_log_index.py
+++ b/services/cart/tests/integration/test_request_log_index.py
@@ -1,0 +1,129 @@
+# Copyright 2026 masa@kugel
+"""The request-log index, and what it used to constrain (issue #182).
+
+The index was written for per-terminal separation and keyed on `store_code` and
+`terminal_no` at the top level — where a request log document does not have them;
+they live under `terminal_info`. Missing fields index as null, so it resolved to
+`(tenant_id, null, null, accept_time)` and enforced *one request per tenant per
+timestamp*, across every terminal in that tenant. It has never done the job it
+was given.
+
+It is also no longer unique. What a unique index here could protect against — the
+same request written twice — does not happen: `insert_many` stamps `_id` into the
+documents in place, so a retried batch is refused by `_id` (issue #183). What it
+did do was reject audit records that legitimately happened, silently.
+
+Here rather than in `services/commons` because the subject is the collection: the
+keys the index actually resolves to, and whether MongoDB accepts the rows.
+"""
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from kugel_common.database import database as db_helper
+
+from app.database import database_setup
+
+pytestmark = pytest.mark.asyncio
+
+STALE_KEYS = ("tenant_id", "store_code", "terminal_no", "request_info.accept_time")
+WANTED_KEYS = (
+    "tenant_id",
+    "terminal_info.store_code",
+    "terminal_info.terminal_no",
+    "request_info.accept_time",
+)
+
+
+def _row(store_code, terminal_no, accept_time):
+    """A request log row, shaped the way the middleware writes one."""
+    return {
+        "tenant_id": os.environ.get("TENANT_ID"),
+        "client_info": {"ip_address": "127.0.0.1"},
+        "request_info": {"method": "POST", "url": "/probe", "body": None, "accept_time": accept_time},
+        "response_info": {"status_code": 200, "process_time_ms": 1, "body": None},
+        "terminal_info": {
+            "tenant_id": os.environ.get("TENANT_ID"),
+            "store_code": store_code,
+            "terminal_no": terminal_no,
+            "business_date": "20260822",
+            "open_counter": 1,
+        },
+    }
+
+
+async def _indexes(collection):
+    info = await collection.index_information()
+    return {name: (tuple(k for k, _ in i["key"]), bool(i.get("unique"))) for name, i in info.items() if name != "_id_"}
+
+
+@pytest_asyncio.fixture
+async def request_log():
+    """The tenant's request-log collection, restored afterwards."""
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    collection = db[os.environ.get("DB_COLLECTION_NAME_REQUEST_LOG", "log_request")]
+    yield collection
+    await collection.delete_many({"request_info.url": "/probe"})
+    await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+
+
+class TestTheIndexThisCollectionGets:
+    async def test_it_is_keyed_on_the_paths_that_exist(self, request_log):
+        await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+
+        keys = {k for k, _ in (await _indexes(request_log)).values()}
+
+        assert WANTED_KEYS in keys, f"the corrected index is not there: {keys}"
+        assert STALE_KEYS not in keys, "the index keyed on fields that do not exist is still there"
+
+    async def test_it_is_not_unique(self, request_log):
+        await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+
+        unique = {k: u for k, u in (await _indexes(request_log)).values()}
+
+        assert unique[WANTED_KEYS] is False
+
+
+class TestWhatTheCollectionNowAccepts:
+    async def test_two_terminals_at_the_same_instant_are_both_kept(self, request_log):
+        # The record this collection exists to hold. Under the old index these
+        # collided on (tenant, null, null, accept_time) and one was refused - an
+        # audit row for a request that happened, dropped because another terminal
+        # was busy at the same microsecond.
+        await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+        instant = f"2099-01-01T00:00:00.{uuid.uuid4().hex[:6]}"
+
+        await request_log.insert_many([_row("5678", 9, instant), _row("9999", 1, instant)])
+
+        assert await request_log.count_documents({"request_info.accept_time": instant}) == 2
+
+    async def test_one_terminal_twice_at_the_same_instant_is_also_kept(self, request_log):
+        # An audit trail should not be the thing that decides a record did not
+        # happen. Rejecting it loses the row; keeping it costs a duplicate that
+        # is visible.
+        await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+        instant = f"2099-01-01T00:00:01.{uuid.uuid4().hex[:6]}"
+
+        await request_log.insert_many([_row("5678", 9, instant), _row("5678", 9, instant)])
+
+        assert await request_log.count_documents({"request_info.accept_time": instant}) == 2
+
+
+class TestTheMigration:
+    async def test_a_collection_carrying_the_old_index_is_moved_over(self, request_log):
+        """What an upgraded deployment starts from."""
+        await request_log.drop_indexes()
+        await request_log.create_index(
+            [(k, 1) for k in STALE_KEYS],
+            name="log_request_index_tenant_id_store_code_terminal_no_request_info.accept_time",
+            unique=True,
+        )
+        assert STALE_KEYS in {k for k, _ in (await _indexes(request_log)).values()}, "precondition"
+
+        await database_setup.create_request_log_collection(os.environ.get("TENANT_ID"))
+
+        keys = {k for k, _ in (await _indexes(request_log)).values()}
+        assert STALE_KEYS not in keys, "the old index survived the migration"
+        assert WANTED_KEYS in keys

--- a/services/journal/app/database/database_setup.py
+++ b/services/journal/app/database/database_setup.py
@@ -126,10 +126,36 @@ async def create_journal_collection(tenant_id: str):
 async def create_request_log_collection(tenant_id: str):
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/master-data/app/database/database_setup.py
+++ b/services/master-data/app/database/database_setup.py
@@ -13,10 +13,20 @@ logger = getLogger(__name__)
 
 
 # create some collection
-async def create_some_collection(tenant_id: str, collection_name: str, index_keys_list: list, index_name: str):
+async def create_some_collection(
+    tenant_id: str,
+    collection_name: str,
+    index_keys_list: list,
+    index_name: str,
+    drop_indexes_by_keys: list = None,
+):
     db_name = f"{settings.DB_NAME_PREFIX}_{tenant_id}"
     await db_helper.create_collection_with_indexes_async(
-        db_name=db_name, collection_name=collection_name, index_keys_list=index_keys_list, index_name=index_name
+        db_name=db_name,
+        collection_name=collection_name,
+        index_keys_list=index_keys_list,
+        index_name=index_name,
+        drop_indexes_by_keys=drop_indexes_by_keys,
     )
 
 
@@ -114,10 +124,36 @@ async def create_master_promotion_collection(tenant_id: str):
 async def create_request_log_collection(tenant_id: str):
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/report/app/database/database_setup.py
+++ b/services/report/app/database/database_setup.py
@@ -102,10 +102,36 @@ async def create_open_close_log_collection(tenant_id: str):
 async def create_request_log_collection(tenant_id: str):
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/stock/app/database/database_setup.py
+++ b/services/stock/app/database/database_setup.py
@@ -97,10 +97,36 @@ async def create_stock_snapshot_collection(tenant_id: str):
 async def create_request_log_collection(tenant_id: str):
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 

--- a/services/terminal/app/database/database_setup.py
+++ b/services/terminal/app/database/database_setup.py
@@ -13,6 +13,7 @@ async def create_some_collection(
     collection_name: str,
     index_keys_list: list,
     index_name: str,
+    drop_indexes_by_keys: list = None,
 ):
     """
     Creates a MongoDB collection with specified indexes.
@@ -22,6 +23,9 @@ async def create_some_collection(
         collection_name: Name of the collection to create
         index_keys_list: List of index key definitions for the collection
         index_name: Name for the created index
+        drop_indexes_by_keys: Index key patterns to retire first, matched by
+            pattern rather than by name (issue #182 uses it to replace the
+            index keyed on fields a request log document does not have)
 
     Returns:
         None
@@ -34,7 +38,11 @@ async def create_some_collection(
 
     # Create the collection with indexes
     await db_helper.create_collection_with_indexes_async(
-        db_name=db_name, collection_name=collection_name, index_keys_list=index_keys_list, index_name=index_name
+        db_name=db_name,
+        collection_name=collection_name,
+        index_keys_list=index_keys_list,
+        index_name=index_name,
+        drop_indexes_by_keys=drop_indexes_by_keys,
     )
 
 
@@ -114,10 +122,36 @@ async def create_request_log_collection(tenant_id: str):
     """
     name = settings.DB_COLLECTION_NAME_REQUEST_LOG
     index_key_list = [
-        {"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}, "unique": True}
+        # Issue #182: the key columns were `store_code` and `terminal_no` at the
+        # top level, where a request log document does not have them - they live
+        # under `terminal_info`. So the index resolved to
+        # (tenant_id, null, null, accept_time) and the constraint it enforced was
+        # one request per tenant per timestamp, never the per-terminal separation
+        # it was written for.
+        #
+        # Corrected to the paths that exist, and no longer unique. What a unique
+        # index here could protect against - the same request written twice - does
+        # not happen: insert_many stamps `_id` into the documents in place, so a
+        # retried batch is refused by `_id` (issue #183). What it did do was
+        # reject audit records that legitimately happened, silently; measured at
+        # 66 rows across this environment.
+        {
+            "keys": {
+                "tenant_id": 1,
+                "terminal_info.store_code": 1,
+                "terminal_info.terminal_no": 1,
+                "request_info.accept_time": 1,
+            },
+            "unique": False,
+        }
     ]
     await create_some_collection(
-        tenant_id=tenant_id, collection_name=name, index_keys_list=index_key_list, index_name=name + "_index"
+        tenant_id=tenant_id,
+        collection_name=name,
+        index_keys_list=index_key_list,
+        index_name=name + "_index",
+        # Retire the index keyed on fields that do not exist (issue #182).
+        drop_indexes_by_keys=[{"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1}],
     )
 
 


### PR DESCRIPTION
Closes #182.

## The defect

Every service created its `log_request` collection with this index:

```python
{"keys": {"tenant_id": 1, "store_code": 1, "terminal_no": 1, "request_info.accept_time": 1},
 "unique": True}
```

A request log document has **no `store_code` or `terminal_no` at the top level** — they live under `terminal_info`:

```
_id, shard_key, created_at, updated_at, etag, tenant_id, client_info,
request_info, response_info, staff_info, user_info, terminal_info, snapshot_info
```

Missing fields index as null, so the key was `(tenant_id, null, null, accept_time)` for every document. The constraint it actually enforced was **one request per tenant per timestamp**, across every terminal in that tenant. It has never done the job it was written for, under any credential.

## Two changes

**The paths are corrected** to `terminal_info.store_code` / `terminal_info.terminal_no`.

**The uniqueness is dropped**, and that is the deliberate part.

What a unique index here could protect against — the same request written twice — does not happen. `insert_many` stamps `_id` into the documents in place, so a retried batch is refused by `_id`, verified in #183:

```
after insert:  [{'a': 1, '_id': ObjectId('…')}, {'a': 2, '_id': ObjectId('…')}]
retry:         BulkWriteError, 2 refused, nInserted=0
final count:   2          ← not 4
```

What it *did* do was reject audit records that legitimately happened, and drop them silently. Measured by comparing the tenant databases against the commons copies, which carry no such index:

```
audit rows the current constraint would have dropped: 66
```

An audit trail should not be the thing that decides a record did not happen. Kept as a query index, which is what it is genuinely useful for.

## Migration

The stale index is retired by key pattern through the existing `drop_indexes_by_keys` mechanism, and the end-state verification added in #186 hard-fails if it survives. Three services' `create_some_collection` did not forward that parameter and now do.

Checked against the running stack, on a collection put back into the pre-#182 state:

```
before: [["tenant_id,store_code,terminal_no,request_info.accept_time", true]]
after : [["tenant_id,terminal_info.store_code,terminal_info.terminal_no,request_info.accept_time", false]]
```

**Existing data cannot block it.** Scanned 259 tenant `log_request` collections holding 21,929 rows: **0** collide under the corrected key. That matters because #185 is exactly what happens when they do.

## This needed #181 first

Before it, JWT requests recorded `terminal_no: 0`. The corrected index would then have started enforcing per-terminal uniqueness over rows that all claimed the same terminal — and one of the 66 dropped rows is precisely that case:

```
db_cloud_cart_commons {"ts":"2026-08-08T09:38:34.495808+09:00","rows":2,"terminals":[0]}
```

## Verification

| mutation | tests that fail |
|---|---|
| restore the wrong key paths | all 5 (setup can no longer complete) |
| restore `unique` | 2 |
| skip the migration drop | 1 |

commons unit 581 · every service's unit suite · all integration · all e2e — green.

## Related

- #181 — the prerequisite, merged
- #185 — what a blocked index costs, and the reporting that would now name it
- #183 — where the `_id` idempotency was established

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB
