### PR TITLE
test(cart): replaying a pre-bill snapshot after finalize records one sale (#152)

### DIFF
--- a/services/cart/tests/e2e/test_replayed_finalize.py
+++ b/services/cart/tests/e2e/test_replayed_finalize.py
@@ -52,15 +52,25 @@ async def _tenant_is_set_up(http_client):
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _remove_synthetic_transactions():
-    yield
+async def carts_created():
+    """Collect this suite's carts, and take only those back out afterwards.
+
+    Deleting by a `transaction_no >= base` floor is how the neighbouring suites
+    do it, and it reaches across them: the bases are 9000, 9500 and 9600, so the
+    lowest floor deletes everything above it. Harmless while the suites run one
+    after another, and not something to leave for whoever runs them in parallel.
+    """
+    created = []
+    yield created
+
     from kugel_common.database import database as db_helper
 
     db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
-    await db["log_tran"].delete_many({"transaction_no": {"$gte": SYNTHETIC_SEQ_BASE}})
+    if created:
+        await db["log_tran"].delete_many({"cart_id": {"$in": created}})
 
 
-async def _cart_ready_to_bill(http_client, terminal_id, header):
+async def _cart_ready_to_bill(http_client, terminal_id, header, created=None):
     """Take a cart to `paying` and return its cart_id with the snapshot from there."""
     response = await http_client.post(
         f"/api/v1/carts?terminal_id={terminal_id}",
@@ -69,6 +79,8 @@ async def _cart_ready_to_bill(http_client, terminal_id, header):
     )
     assert response.status_code == status.HTTP_201_CREATED, response.text
     cart_id = response.json()["data"]["cartId"]
+    if created is not None:
+        created.append(cart_id)
 
     response = await http_client.post(
         f"/api/v1/carts/{cart_id}/lineItems?terminal_id={terminal_id}",
@@ -116,9 +128,9 @@ def _finalize(snapshot, seq, counter):
 
 
 @pytest.mark.asyncio
-async def test_the_sale_is_recorded_once(http_client, api_header, opened_terminal_id):
+async def test_the_sale_is_recorded_once(http_client, api_header, opened_terminal_id, carts_created):
     """SC-004 of #148: exactly one recorded transaction per cart_id."""
-    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
     url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
     request = _finalize(paying, SYNTHETIC_SEQ_BASE + 1, 61)
 
@@ -134,26 +146,34 @@ async def test_the_sale_is_recorded_once(http_client, api_header, opened_termina
 
 
 @pytest.mark.asyncio
-async def test_the_replay_is_answered_with_the_transaction_that_exists(http_client, api_header, opened_terminal_id):
+async def test_the_replay_is_answered_with_the_transaction_that_exists(
+    http_client, api_header, opened_terminal_id, carts_created
+):
     """Idempotent, not merely refused.
 
     A terminal replays because it did not hear the first answer; telling it the
     request is invalid leaves it with a sale it cannot account for. It gets the
     numbers that were actually recorded.
     """
-    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
     url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
     request = _finalize(paying, SYNTHETIC_SEQ_BASE + 2, 62)
 
     first = await http_client.post(url, json=request, headers=api_header)
     replayed = await http_client.post(url, json=request, headers=api_header)
 
+    assert first.status_code == status.HTTP_200_OK, first.text
+    assert replayed.status_code == status.HTTP_200_OK, (
+        f"the replay was refused rather than answered idempotently: {replayed.text}"
+    )
     assert replayed.json()["data"]["transactionNo"] == first.json()["data"]["transactionNo"]
     assert replayed.json()["data"]["receiptNo"] == first.json()["data"]["receiptNo"]
 
 
 @pytest.mark.asyncio
-async def test_a_replay_claiming_other_numbers_still_records_one_sale(http_client, api_header, opened_terminal_id):
+async def test_a_replay_claiming_other_numbers_still_records_one_sale(
+    http_client, api_header, opened_terminal_id, carts_created
+):
     """The identity is the cart, not the numbers carried with it.
 
     `__is_same_finalize` compares (transaction_type, is_cancelled), so a replay
@@ -166,7 +186,7 @@ async def test_a_replay_claiming_other_numbers_still_records_one_sale(http_clien
     not the ones it sent. Nothing on the server distinguishes this from an
     identical retry, which is worth knowing when reading the log.
     """
-    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
     url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
 
     first = await http_client.post(url, json=_finalize(paying, SYNTHETIC_SEQ_BASE + 3, 63), headers=api_header)
@@ -182,13 +202,15 @@ async def test_a_replay_claiming_other_numbers_still_records_one_sale(http_clien
 
 
 @pytest.mark.asyncio
-async def test_a_different_operation_on_the_same_cart_is_refused(http_client, api_header, opened_terminal_id):
+async def test_a_different_operation_on_the_same_cart_is_refused(
+    http_client, api_header, opened_terminal_id, carts_created
+):
     """A cancel is not a retry of a sale, whatever cart it names.
 
     Answering that idempotently would tell a terminal its cancellation
     succeeded while a completed sale stands.
     """
-    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
 
     billed = await http_client.post(
         f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}",
@@ -203,19 +225,25 @@ async def test_a_different_operation_on_the_same_cart_is_refused(http_client, ap
         headers=api_header,
     )
 
-    assert cancelled.status_code != status.HTTP_200_OK, "a cancel was accepted as a retry of a completed sale"
+    # The specific refusal, not merely a non-200: with the dedupe gone the unique
+    # index refuses the insert too, and a 500 from that would satisfy `!= 200`
+    # while saying the opposite about the code under test.
+    assert cancelled.status_code == status.HTTP_409_CONFLICT, (
+        f"expected the deliberate finalize conflict, got {cancelled.status_code}: {cancelled.text}"
+    )
+    assert "401511" in cancelled.text, f"not the finalize-conflict error code: {cancelled.text}"
     assert len(await _tranlogs_for(cart_id)) == 1
 
 
 @pytest.mark.asyncio
-async def test_the_recorded_transaction_names_its_cart(http_client, api_header, opened_terminal_id):
+async def test_the_recorded_transaction_names_its_cart(http_client, api_header, opened_terminal_id, carts_created):
     """What the dedupe is keyed on has to actually be in the row.
 
     Historical transactions have no cart_id and the index is partial for that
     reason - so an absent one is not an error anywhere, and nothing else would
     notice if new rows stopped carrying it.
     """
-    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
 
     await http_client.post(
         f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}",

--- a/services/cart/tests/e2e/test_replayed_finalize.py
+++ b/services/cart/tests/e2e/test_replayed_finalize.py
@@ -1,0 +1,228 @@
+# Copyright 2026 masa@kugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Replaying a pre-bill snapshot of a transaction that is already finalized (issue #152).
+
+The double-count path #148 left open, in full: a terminal holds a snapshot taken
+while the cart was still `paying`, the cart is billed, the cart leaves the cache
+— and the old snapshot is presented again. Its signature is valid, it is not
+itself a terminal-state cart, and the server it reaches has no cart to compare
+it against. Before `cart_id` became the transaction identity, the second bill
+issued a fresh `transaction_no` and the same sale was recorded twice.
+
+Distinct from #172, which races two finalizes at once and is about the loser of
+a commit. This is the sequential case, and it is the one the issue names: the
+replay arrives long after the first has been written and acknowledged.
+
+End-to-end because what is being asserted is the row count in the transaction
+log — the dedupe lives in a partial-unique index, and an index is not something
+a mock has.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+
+# Kept above the numbering the rest of the suite produces, and removed
+# afterwards; a carried seq has to be unique inside the open session.
+SYNTHETIC_SEQ_BASE = 9600
+
+
+@pytest.fixture
+def api_header():
+    return {"X-API-KEY": os.environ.get("API_KEY")}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _tenant_is_set_up(http_client):
+    """The dedupe is a unique index, so the tenant has to be set up.
+
+    Without it both writes land and the count below measures an unconfigured
+    database rather than the behaviour (same reason as the #172 suite).
+    """
+    from tests.e2e.test_cart import create_tenant, get_authentication_token
+
+    await create_tenant(http_client, await get_authentication_token())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _remove_synthetic_transactions():
+    yield
+    from kugel_common.database import database as db_helper
+
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    await db["log_tran"].delete_many({"transaction_no": {"$gte": SYNTHETIC_SEQ_BASE}})
+
+
+async def _cart_ready_to_bill(http_client, terminal_id, header):
+    """Take a cart to `paying` and return its cart_id with the snapshot from there."""
+    response = await http_client.post(
+        f"/api/v1/carts?terminal_id={terminal_id}",
+        json={"transaction_type": 101, "user_id": "99", "user_name": "Replayed finalize"},
+        headers=header,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    cart_id = response.json()["data"]["cartId"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/lineItems?terminal_id={terminal_id}",
+        json=[{"itemCode": "49-01", "quantity": 1}],
+        headers=header,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    snapshot = response.json()["data"]["signedSnapshot"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/subtotal?terminal_id={terminal_id}",
+        json={"signedSnapshot": snapshot, "payload": {}},
+        headers=header,
+    )
+    data = response.json()["data"]
+
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/payments?terminal_id={terminal_id}",
+        json={
+            "signedSnapshot": data["signedSnapshot"],
+            "payload": [{"paymentCode": "01", "amount": int(data["balanceAmount"])}],
+        },
+        headers=header,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return cart_id, response.json()["data"]["signedSnapshot"]
+
+
+async def _tranlogs_for(cart_id):
+    from kugel_common.database import database as db_helper
+
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    return await db["log_tran"].find({"cart_id": cart_id}).to_list(length=10)
+
+
+def _finalize(snapshot, seq, counter):
+    return {
+        "signedSnapshot": snapshot,
+        "payload": {
+            "seq": seq,
+            "receiptCounter": counter,
+            "transactionDatetime": "2026-08-22T09:00:00",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_sale_is_recorded_once(http_client, api_header, opened_terminal_id):
+    """SC-004 of #148: exactly one recorded transaction per cart_id."""
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+    request = _finalize(paying, SYNTHETIC_SEQ_BASE + 1, 61)
+
+    first = await http_client.post(url, json=request, headers=api_header)
+    assert first.status_code == status.HTTP_200_OK, first.text
+
+    # The same pre-bill snapshot, presented again after the cart is finalized and
+    # gone from the cache. Nothing about the envelope says it is stale.
+    replayed = await http_client.post(url, json=request, headers=api_header)
+
+    assert replayed.status_code == status.HTTP_200_OK, replayed.text
+    assert len(await _tranlogs_for(cart_id)) == 1, "the replayed snapshot was recorded as a second sale"
+
+
+@pytest.mark.asyncio
+async def test_the_replay_is_answered_with_the_transaction_that_exists(http_client, api_header, opened_terminal_id):
+    """Idempotent, not merely refused.
+
+    A terminal replays because it did not hear the first answer; telling it the
+    request is invalid leaves it with a sale it cannot account for. It gets the
+    numbers that were actually recorded.
+    """
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+    request = _finalize(paying, SYNTHETIC_SEQ_BASE + 2, 62)
+
+    first = await http_client.post(url, json=request, headers=api_header)
+    replayed = await http_client.post(url, json=request, headers=api_header)
+
+    assert replayed.json()["data"]["transactionNo"] == first.json()["data"]["transactionNo"]
+    assert replayed.json()["data"]["receiptNo"] == first.json()["data"]["receiptNo"]
+
+
+@pytest.mark.asyncio
+async def test_a_replay_claiming_other_numbers_still_records_one_sale(http_client, api_header, opened_terminal_id):
+    """The identity is the cart, not the numbers carried with it.
+
+    `__is_same_finalize` compares (transaction_type, is_cancelled), so a replay
+    that claims a different seq and counter for the same cart is still the same
+    finalize. It is answered with what was recorded rather than what it asked
+    for - which is the honest answer: recording it would be the double-count,
+    and refusing it would leave a terminal holding a sale it cannot account for.
+
+    The terminal can see the difference, because the numbers it gets back are
+    not the ones it sent. Nothing on the server distinguishes this from an
+    identical retry, which is worth knowing when reading the log.
+    """
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+
+    first = await http_client.post(url, json=_finalize(paying, SYNTHETIC_SEQ_BASE + 3, 63), headers=api_header)
+    assert first.status_code == status.HTTP_200_OK, first.text
+
+    divergent = await http_client.post(url, json=_finalize(paying, SYNTHETIC_SEQ_BASE + 4, 64), headers=api_header)
+
+    assert divergent.status_code == status.HTTP_200_OK, divergent.text
+    assert len(await _tranlogs_for(cart_id)) == 1, "a replay with other numbers was recorded as a second sale"
+    # What came back is the recorded transaction, not the one that was claimed.
+    assert divergent.json()["data"]["transactionNo"] == SYNTHETIC_SEQ_BASE + 3
+    assert divergent.json()["data"]["transactionNo"] == first.json()["data"]["transactionNo"]
+
+
+@pytest.mark.asyncio
+async def test_a_different_operation_on_the_same_cart_is_refused(http_client, api_header, opened_terminal_id):
+    """A cancel is not a retry of a sale, whatever cart it names.
+
+    Answering that idempotently would tell a terminal its cancellation
+    succeeded while a completed sale stands.
+    """
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+
+    billed = await http_client.post(
+        f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}",
+        json=_finalize(paying, SYNTHETIC_SEQ_BASE + 6, 66),
+        headers=api_header,
+    )
+    assert billed.status_code == status.HTTP_200_OK, billed.text
+
+    cancelled = await http_client.post(
+        f"/api/v1/carts/{cart_id}/cancel?terminal_id={opened_terminal_id}",
+        json=_finalize(paying, SYNTHETIC_SEQ_BASE + 7, 67),
+        headers=api_header,
+    )
+
+    assert cancelled.status_code != status.HTTP_200_OK, "a cancel was accepted as a retry of a completed sale"
+    assert len(await _tranlogs_for(cart_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_recorded_transaction_names_its_cart(http_client, api_header, opened_terminal_id):
+    """What the dedupe is keyed on has to actually be in the row.
+
+    Historical transactions have no cart_id and the index is partial for that
+    reason - so an absent one is not an error anywhere, and nothing else would
+    notice if new rows stopped carrying it.
+    """
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header)
+
+    await http_client.post(
+        f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}",
+        json=_finalize(paying, SYNTHETIC_SEQ_BASE + 5, 65),
+        headers=api_header,
+    )
+
+    rows = await _tranlogs_for(cart_id)
+    assert len(rows) == 1
+    assert rows[0]["cart_id"] == cart_id

--- a/services/cart/tests/integration/test_index_blocking_report.py
+++ b/services/cart/tests/integration/test_index_blocking_report.py
@@ -191,3 +191,47 @@ class TestAnIndexWithTheRightKeysAndTheWrongOptions:
             index_keys_list=[{"keys": KEYS, "unique": True}],
             index_name="probe_index",
         )
+
+
+class TestTheTranlogDedupeIndexIsPartialForAReason:
+    """Transactions predating `cart_id` have none, and must still coexist.
+
+    The dedupe index on (tenant_id, store_code, cart_id) is unique, so without a
+    partial filter every historical row would collide with every other on a
+    missing key — and the collection could never be indexed at all. Nothing else
+    would notice the filter being dropped until a tenant with history could not
+    be set up, which is what issue #185 looks like from the outside.
+    """
+
+    DEDUPE_KEYS = {"tenant_id": 1, "store_code": 1, "cart_id": 1}
+    PARTIAL = {"cart_id": {"$type": "string"}}
+
+    async def test_rows_without_a_cart_id_do_not_collide(self, collection):
+        db_name, name, db = collection
+        await db[name].insert_many([_tranlog(1), _tranlog(2), _tranlog(3)])  # no cart_id on any
+
+        await create_collection_with_indexes_async(
+            db_name=db_name,
+            collection_name=name,
+            index_keys_list=[{"keys": self.DEDUPE_KEYS, "unique": True, "partialFilterExpression": self.PARTIAL}],
+            index_name="probe_index",
+        )
+
+        # And the collection keeps accepting them afterwards.
+        await db[name].insert_many([_tranlog(4), _tranlog(5)])
+        assert await db[name].count_documents({}) == 5
+
+    async def test_two_rows_with_the_same_cart_id_still_collide(self, collection):
+        db_name, name, db = collection
+        await create_collection_with_indexes_async(
+            db_name=db_name,
+            collection_name=name,
+            index_keys_list=[{"keys": self.DEDUPE_KEYS, "unique": True, "partialFilterExpression": self.PARTIAL}],
+            index_name="probe_index",
+        )
+
+        await db[name].insert_one(_tranlog(1, cart_id="the-same-cart"))
+        with pytest.raises(Exception):
+            await db[name].insert_one(_tranlog(2, cart_id="the-same-cart"))
+
+        assert await db[name].count_documents({}) == 1


### PR DESCRIPTION
Closes #152.

## What was left

#152's three code items landed with #156/#157 and #172 — `cart_id` on the tranlog, the partial-unique index on `(tenant_id, store_code, cart_id)`, and idempotent finalization. Verified against the running stack before writing anything:

```
first bill        : HTTP 200  transactionNo=7303
replayed bill     : HTTP 200  transactionNo=7303
tranlogs for this cart_id: 1
```

What the issue asked for and did not have was the **test**. #172's suite races two finalizes at once; the scenario #152 is named for is sequential — a snapshot taken while the cart was still `paying`, presented again long after the cart is billed and gone from the cache. Its signature is valid, it is not itself a terminal-state cart, and the server has nothing to compare it against.

## Five tests

- the sale is recorded once — SC-004 of #148
- the replay is answered with the transaction that exists, **not refused**: a terminal replays because it did not hear the first answer, and telling it the request is invalid leaves it holding a sale it cannot account for
- a replay claiming a different seq and counter still records one sale, and gets back what was recorded rather than what it asked for
- a cancel of an already-billed cart **is** refused — it is not a retry of a sale
- the recorded transaction names its cart, which nothing else would notice if it stopped doing

End to end because what is asserted is the row count in the transaction log, and the dedupe lives in an index.

## One expectation of mine was wrong

The third started as an assertion that a replay claiming different numbers is refused. It is not: `__is_same_finalize` compares `(transaction_type, is_cancelled)`, so the identity is the cart and the operation, not the numbers carried with it.

The behaviour is defensible — recording it would be the double-count, refusing it would strand the terminal — so the test now pins it rather than the expectation I brought to it. Worth knowing when reading the log: **nothing on the server tells this apart from an identical retry.** The terminal can see it, because the numbers it gets back are not the ones it sent.

## What the mutation testing showed

Mutation-checked against the **running container**, since these talk to the live service.

Neither dedupe layer alone fails these tests, because there are two: a pre-check before the insert, and a recovery after the unique index rejects it. Each covers the other for the sequential case.

| mutation | result |
|---|---|
| disable the pre-check | 5 passed — the recovery path catches it |
| disable the recovery | 5 passed — the pre-check catches it |
| **disable both** | **3 of 5 fail** |

That is the honest way to state what they cover: the dedupe as a mechanism, not either implementation of it.

All e2e — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB
