### PR TITLE
feat(cart): record when a repeated finalize carries different numbers (#190)

### DIFF
--- a/services/cart/app/dependencies/get_cart_service.py
+++ b/services/cart/app/dependencies/get_cart_service.py
@@ -169,7 +169,8 @@ async def __get_cart_service_async(
     tranlog_repo = TranlogRepository(db=db, terminal_info=terminal_info)
     await tranlog_repo.initialize()
     tranlog_delivery_status_repo = TranlogDeliveryStatusRepository(
-        db=db_common, terminal_info=terminal_info  # use common db
+        db=db_common,
+        terminal_info=terminal_info,  # use common db
     )
     await tranlog_delivery_status_repo.initialize()
     transaction_status_repo = TransactionStatusRepository(db=db, terminal_info=terminal_info)
@@ -203,6 +204,7 @@ async def __get_cart_service_async(
         payment_master_repo=payment_master_repo,
         transaction_status_repo=transaction_status_repo,
         store_info_repo=store_info_repo,
+        cart_restore_log_repo=cart_restore_log_repo,
     )
 
     return CartService(

--- a/services/cart/app/services/tran_service.py
+++ b/services/cart/app/services/tran_service.py
@@ -191,6 +191,10 @@ class TranService:
         # downstream cart_id dedupe converges to one record. Without a carried
         # time (legacy / no-snapshot path) the server-side numbering is used.
         carried = cart.transaction_datetime is not None
+        # A repeat is reported once. The insert path can report and then fail to
+        # commit, which lands in the recovery below - and reporting the same
+        # repeat twice doubles every row the audit query is meant to count.
+        reported = False
         if carried:
             # (business_counter, seq) composite: transaction_no carries seq.
             tranlog.transaction_no = cart.seq
@@ -324,12 +328,13 @@ class TranService:
                 payload=event_message,
                 services=event_distinations,
             )
-            carried = tranlog
+            submitted = tranlog
             tranlog = await self.tranlog_repository.create_tranlog_async(tranlog)
-            if tranlog is not carried:
+            if tranlog is not submitted:
                 # Not a fresh insert: the repository returned a tranlog that was
                 # already there, so this finalize was a repeat (issue #152).
-                await self.__report_finalize_repeat_async(carried, tranlog)
+                await self.__report_finalize_repeat_async(submitted, tranlog, carried)
+                reported = True
             await self.tranlog_repository.commit_transaction()
 
         except FinalizeConflictException:
@@ -350,7 +355,9 @@ class TranService:
             # of a 500. The winner already published, so we do NOT publish again.
             existing = await self.__recover_concurrent_finalize(tranlog)
             if existing is not None:
-                await self.__report_finalize_repeat_async(tranlog, existing)
+                if not reported:
+                    await self.__report_finalize_repeat_async(tranlog, existing, carried)
+                    reported = True
                 return self.__apply_tranlog_to_cart(cart, existing)
             # The duplicate was on some other unique index (not the cart_id race) —
             # surface it as a real failure.
@@ -372,7 +379,9 @@ class TranService:
                     tranlog.cart_id,
                     type(e).__name__,
                 )
-                await self.__report_finalize_repeat_async(tranlog, existing)
+                if not reported:
+                    await self.__report_finalize_repeat_async(tranlog, existing, carried)
+                    reported = True
                 return self.__apply_tranlog_to_cart(cart, existing)
             message = f"Error creating tranlog: {e}"
             raise InternalErrorException(message, logger) from e
@@ -1015,16 +1024,39 @@ class TranService:
     # for these is the whole question issue #190 is about.
     CARRIED_FINALIZE_FIELDS = ("transaction_no", "receipt_no", "receipt_counter", "generate_date_time")
 
+    @staticmethod
+    def __same_instant(asked, holds) -> bool:
+        """Whether two stamped times are the same moment, however they are written.
+
+        The carried value is validated as ISO-8601 but not normalised, so the same
+        instant can arrive as `...+00:00` or `...Z`, with or without microseconds.
+        Comparing the strings would report those as a terminal that had moved on.
+        """
+        if asked == holds:
+            return True
+        if not isinstance(asked, str) or not isinstance(holds, str):
+            return False
+        try:
+            return datetime.fromisoformat(asked.replace("Z", "+00:00")) == datetime.fromisoformat(
+                holds.replace("Z", "+00:00")
+            )
+        except (ValueError, TypeError):
+            return False
+
     def __finalize_divergence(self, carried: BaseTransaction, recorded: BaseTransaction) -> dict:
         """What this finalize asked to record that differs from what is recorded."""
         divergence = {}
         for field in self.CARRIED_FINALIZE_FIELDS:
             asked, holds = getattr(carried, field, None), getattr(recorded, field, None)
+            if field == "generate_date_time" and self.__same_instant(asked, holds):
+                continue
             if asked != holds:
                 divergence[field] = {"carried": asked, "recorded": holds}
         return divergence
 
-    async def __report_finalize_repeat_async(self, carried: BaseTransaction, recorded: BaseTransaction) -> None:
+    async def __report_finalize_repeat_async(
+        self, carried: BaseTransaction, recorded: BaseTransaction, client_numbered: bool = True
+    ) -> None:
         """
         Write down that a finalize repeated, and whether it repeated itself (issue #190).
 
@@ -1041,7 +1073,13 @@ class TranService:
         The first is worth chasing and the second is not, and until now they left
         the same single line behind.
         """
-        divergence = self.__finalize_divergence(carried, recorded)
+        # Only when the terminal supplied the numbers. On the server-numbered
+        # path the numbers in hand were issued by this request from the server's
+        # own counter and clock, so a race against a concurrent finalize differs
+        # by construction - measured at "carried 50 vs recorded 49" for two
+        # simultaneous bills - and says nothing at all about the terminal. Filing
+        # that would bury the rows that do mean something.
+        divergence = self.__finalize_divergence(carried, recorded) if client_numbered else {}
         if not divergence:
             logger.warning(
                 "Finalize repeated for cart_id=%s carrying the same numbers; "

--- a/services/cart/app/services/tran_service.py
+++ b/services/cart/app/services/tran_service.py
@@ -192,8 +192,11 @@ class TranService:
         # time (legacy / no-snapshot path) the server-side numbering is used.
         carried = cart.transaction_datetime is not None
         # A repeat is reported once. The insert path can report and then fail to
-        # commit, which lands in the recovery below - and reporting the same
-        # repeat twice doubles every row the audit query is meant to count.
+        # commit, which lands in the recovery below - where the tranlog in hand
+        # is by then the recorded one, so a second report finds no divergence and
+        # says the repeat carried the same numbers, directly after a line saying
+        # it carried different ones. The audit row is not at risk; the
+        # contradiction in the log is, and that is what a reader works from.
         reported = False
         if carried:
             # (business_counter, seq) composite: transaction_no carries seq.

--- a/services/cart/app/services/tran_service.py
+++ b/services/cart/app/services/tran_service.py
@@ -21,6 +21,7 @@ from kugel_common.utils.slack_notifier import send_warning_notification
 from kugel_common.exceptions import DuplicateKeyException
 
 from app.models.repositories.tranlog_repository import TranlogRepository
+from app.models.repositories.cart_restore_log_repository import CartRestoreLogRepository
 from app.models.repositories.tranlog_delivery_status_repository import (
     TranlogDeliveryStatusRepository,
 )
@@ -75,6 +76,7 @@ class TranService:
         payment_master_repo: PaymentMasterWebRepository,
         transaction_status_repo: TransactionStatusRepository,
         store_info_repo: StoreInfoWebRepository = None,
+        cart_restore_log_repo: CartRestoreLogRepository = None,
     ):
         """
         Initialize the transaction service with required repositories and information.
@@ -91,6 +93,10 @@ class TranService:
         self.tranlog_repository = tranlog_repo
         self.tranlog_delivery_status_repo = tranlog_delivery_status_repo
         self.settings_master_repo = settings_master_repo
+        # Where a finalize whose carried numbers do not match the recorded ones
+        # is written down (issue #190). Optional: a caller that does not supply
+        # it still gets the log line.
+        self.cart_restore_log_repo = cart_restore_log_repo
         self.payment_master_repo = payment_master_repo
         # Used to name the store a return is booked into: a return may reference an
         # original from another store (issue #156), so the new transaction must be
@@ -318,7 +324,12 @@ class TranService:
                 payload=event_message,
                 services=event_distinations,
             )
+            carried = tranlog
             tranlog = await self.tranlog_repository.create_tranlog_async(tranlog)
+            if tranlog is not carried:
+                # Not a fresh insert: the repository returned a tranlog that was
+                # already there, so this finalize was a repeat (issue #152).
+                await self.__report_finalize_repeat_async(carried, tranlog)
             await self.tranlog_repository.commit_transaction()
 
         except FinalizeConflictException:
@@ -339,6 +350,7 @@ class TranService:
             # of a 500. The winner already published, so we do NOT publish again.
             existing = await self.__recover_concurrent_finalize(tranlog)
             if existing is not None:
+                await self.__report_finalize_repeat_async(tranlog, existing)
                 return self.__apply_tranlog_to_cart(cart, existing)
             # The duplicate was on some other unique index (not the cart_id race) —
             # surface it as a real failure.
@@ -356,11 +368,11 @@ class TranService:
                 # Deliberately terse: the exception carries the whole tranlog, and
                 # one race must not put a full cart document in the log (issue #155).
                 logger.warning(
-                    "Finalize failed but the same finalize is already persisted "
-                    "(cart_id=%s, %s); returning it",
+                    "Finalize failed but the same finalize is already persisted (cart_id=%s, %s); returning it",
                     tranlog.cart_id,
                     type(e).__name__,
                 )
+                await self.__report_finalize_repeat_async(tranlog, existing)
                 return self.__apply_tranlog_to_cart(cart, existing)
             message = f"Error creating tranlog: {e}"
             raise InternalErrorException(message, logger) from e
@@ -509,9 +521,7 @@ class TranService:
             )
             raise VoidOutOfSessionException(message, logger)
 
-    async def _resolve_carried_finalize(
-        self, finalize_envelope: dict | None
-    ) -> tuple[str, int, int, str]:
+    async def _resolve_carried_finalize(self, finalize_envelope: dict | None) -> tuple[str, int, int, str]:
         """
         Resolve ``(cart_id, transaction_no, receipt_no, generate_date_time,
         receipt_counter)`` for a
@@ -776,12 +786,14 @@ class TranService:
         if tran.transaction_type == TransactionType.VoidReturn.value:
             # The origin contains the return transaction info
             # We need to find the original sale transaction that was refunded
-            return_tran = await self.tranlog_repository.get_one_async({
-                "tenant_id": tran.origin.tenant_id,
-                "store_code": tran.origin.store_code,
-                "terminal_no": tran.origin.terminal_no,
-                "transaction_no": tran.origin.transaction_no,
-            })
+            return_tran = await self.tranlog_repository.get_one_async(
+                {
+                    "tenant_id": tran.origin.tenant_id,
+                    "store_code": tran.origin.store_code,
+                    "terminal_no": tran.origin.terminal_no,
+                    "transaction_no": tran.origin.transaction_no,
+                }
+            )
 
             if return_tran and return_tran.origin:
                 # Reset the refund status on the original sale transaction
@@ -999,6 +1011,69 @@ class TranService:
 
         return tran
 
+    # The finalize context a terminal carries (issue #156). What a repeat claims
+    # for these is the whole question issue #190 is about.
+    CARRIED_FINALIZE_FIELDS = ("transaction_no", "receipt_no", "receipt_counter", "generate_date_time")
+
+    def __finalize_divergence(self, carried: BaseTransaction, recorded: BaseTransaction) -> dict:
+        """What this finalize asked to record that differs from what is recorded."""
+        divergence = {}
+        for field in self.CARRIED_FINALIZE_FIELDS:
+            asked, holds = getattr(carried, field, None), getattr(recorded, field, None)
+            if asked != holds:
+                divergence[field] = {"carried": asked, "recorded": holds}
+        return divergence
+
+    async def __report_finalize_repeat_async(self, carried: BaseTransaction, recorded: BaseTransaction) -> None:
+        """
+        Write down that a finalize repeated, and whether it repeated itself (issue #190).
+
+        A terminal repeats because it did not hear the first answer, and it is
+        answered with the transaction that exists - which is right, and which the
+        log already said. What it did not say is whether the repeat carried the
+        SAME numbers.
+
+        It usually does: a terminal that heard nothing has not advanced. When it
+        does not, the terminal's running receipt counter has moved past what was
+        recorded, and that means one of three things - it printed a receipt whose
+        number is in no transaction log, or it advanced without printing (a gap,
+        which issue #166 allows), or a different transaction reused the cart_id.
+        The first is worth chasing and the second is not, and until now they left
+        the same single line behind.
+        """
+        divergence = self.__finalize_divergence(carried, recorded)
+        if not divergence:
+            logger.warning(
+                "Finalize repeated for cart_id=%s carrying the same numbers; "
+                "answered with the transaction already recorded",
+                recorded.cart_id,
+            )
+            return
+
+        logger.error(
+            "Finalize repeated for cart_id=%s carrying DIFFERENT numbers (issue #190): %s. "
+            "The terminal has moved past what is recorded; a printed receipt may carry a "
+            "number that appears in no transaction log.",
+            recorded.cart_id,
+            divergence,
+        )
+        if self.cart_restore_log_repo is None:
+            return
+        try:
+            await self.cart_restore_log_repo.add_record_async(
+                result="finalize_repeat_diverged",
+                cart_id=recorded.cart_id,
+                diverged=True,
+                reject_reason=", ".join(
+                    f"{field}: carried {values['carried']} vs recorded {values['recorded']}"
+                    for field, values in divergence.items()
+                ),
+            )
+        except Exception as e:
+            # The transaction is recorded and answered; losing the note about it
+            # must not turn that into a failure.
+            logger.error(f"Could not record the finalize divergence for cart_id={recorded.cart_id}: {e}")
+
     def __apply_tranlog_to_cart(self, cart: CartDocument, tranlog: BaseTransaction) -> BaseTransaction:
         """
         Copy the finalized transaction's identity onto the cart the caller holds.
@@ -1050,8 +1125,7 @@ class TranService:
         existing = await self.tranlog_repository.get_existing_finalize_async(tranlog)
         if existing is not None:
             logger.warning(
-                f"Concurrent finalize race for cart_id={tranlog.cart_id}; "
-                "returning the winning tranlog idempotently"
+                f"Concurrent finalize race for cart_id={tranlog.cart_id}; returning the winning tranlog idempotently"
             )
         return existing
 
@@ -1112,8 +1186,7 @@ class TranService:
             # it the derived number would leave the configured range entirely, so
             # prefer whatever the terminal printed and say so loudly.
             logger.error(
-                "Receipt number range unavailable (counter=%s); "
-                "%s. Check master-data reachability.",
+                "Receipt number range unavailable (counter=%s); %s. Check master-data reachability.",
                 receipt_counter,
                 (
                     "recording the number the terminal printed"

--- a/services/cart/tests/e2e/test_replayed_finalize.py
+++ b/services/cart/tests/e2e/test_replayed_finalize.py
@@ -68,6 +68,7 @@ async def carts_created():
     db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
     if created:
         await db["log_tran"].delete_many({"cart_id": {"$in": created}})
+        await db["log_cart_restore"].delete_many({"cart_id": {"$in": created}})
 
 
 async def _cart_ready_to_bill(http_client, terminal_id, header, created=None):
@@ -254,3 +255,91 @@ async def test_the_recorded_transaction_names_its_cart(http_client, api_header, 
     rows = await _tranlogs_for(cart_id)
     assert len(rows) == 1
     assert rows[0]["cart_id"] == cart_id
+
+
+async def _divergence_rows(cart_id):
+    from kugel_common.database import database as db_helper
+
+    db = await db_helper.get_db_async(f"{os.environ.get('DB_NAME_PREFIX')}_{os.environ.get('TENANT_ID')}")
+    return (
+        await db["log_cart_restore"].find({"cart_id": cart_id, "result": "finalize_repeat_diverged"}).to_list(length=10)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_repeat_carrying_other_numbers_is_written_down(
+    http_client, api_header, opened_terminal_id, carts_created
+):
+    """Issue #190, through the service rather than through the helper.
+
+    The unit tests call the reporter directly, so they would all pass with the
+    calls to it removed. This is what says it is wired: the audit row has to come
+    out of a real finalize.
+    """
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+
+    first = await http_client.post(url, json=_finalize(paying, SYNTHETIC_SEQ_BASE + 8, 68), headers=api_header)
+    assert first.status_code == status.HTTP_200_OK, first.text
+    repeat = await http_client.post(url, json=_finalize(paying, SYNTHETIC_SEQ_BASE + 9, 69), headers=api_header)
+    assert repeat.status_code == status.HTTP_200_OK, repeat.text
+
+    rows = await _divergence_rows(cart_id)
+    assert len(rows) == 1, f"the divergence left no audit row: {rows}"
+    reason = rows[0]["reject_reason"]
+    assert "receipt_counter" in reason and "69" in reason and "68" in reason, reason
+    assert rows[0]["diverged"] is True
+
+
+@pytest.mark.asyncio
+async def test_an_identical_repeat_is_not_written_down(http_client, api_header, opened_terminal_id, carts_created):
+    """The ordinary retry must not fill the trail it is meant to keep readable."""
+    cart_id, paying = await _cart_ready_to_bill(http_client, opened_terminal_id, api_header, carts_created)
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+    request = _finalize(paying, SYNTHETIC_SEQ_BASE + 10, 70)
+
+    await http_client.post(url, json=request, headers=api_header)
+    await http_client.post(url, json=request, headers=api_header)
+
+    assert await _divergence_rows(cart_id) == []
+
+
+@pytest.mark.asyncio
+async def test_a_server_numbered_race_is_not_written_down(http_client, api_header, opened_terminal_id, carts_created):
+    """Two simultaneous bills with no snapshot, where the SERVER issues the numbers.
+
+    They differ by construction — the counter hands out 50 and 49 — and that says
+    nothing about a terminal. Measured before the guard: one false row per race.
+    """
+    import asyncio
+
+    response = await http_client.post(
+        f"/api/v1/carts?terminal_id={opened_terminal_id}",
+        json={"transaction_type": 101, "user_id": "99", "user_name": "Server numbered"},
+        headers=api_header,
+    )
+    cart_id = response.json()["data"]["cartId"]
+    carts_created.append(cart_id)
+    await http_client.post(
+        f"/api/v1/carts/{cart_id}/lineItems?terminal_id={opened_terminal_id}",
+        json=[{"itemCode": "49-01", "quantity": 1}],
+        headers=api_header,
+    )
+    response = await http_client.post(
+        f"/api/v1/carts/{cart_id}/subtotal?terminal_id={opened_terminal_id}", json={}, headers=api_header
+    )
+    await http_client.post(
+        f"/api/v1/carts/{cart_id}/payments?terminal_id={opened_terminal_id}",
+        json=[{"paymentCode": "01", "amount": int(response.json()["data"]["balanceAmount"])}],
+        headers=api_header,
+    )
+
+    url = f"/api/v1/carts/{cart_id}/bill?terminal_id={opened_terminal_id}"
+    first, second = await asyncio.gather(
+        http_client.post(url, headers=api_header), http_client.post(url, headers=api_header)
+    )
+
+    assert first.status_code == status.HTTP_200_OK, first.text
+    assert second.status_code == status.HTTP_200_OK, second.text
+    assert len(await _tranlogs_for(cart_id)) == 1
+    assert await _divergence_rows(cart_id) == [], "the server's own numbering was filed as a terminal divergence"

--- a/services/cart/tests/unit/test_finalize_repeat_divergence.py
+++ b/services/cart/tests/unit/test_finalize_repeat_divergence.py
@@ -233,3 +233,130 @@ class TestTheSameInstantWrittenTwoWays:
         await _report(service, _tranlog(when="2026-08-23T00:00:01+09:00"), _tranlog(when="2026-08-22T23:59:59+09:00"))
 
         audit.add_record_async.assert_awaited_once()
+
+
+class TestTheConcurrentRaceReportsItToo:
+    """The race can surface at the insert or at the commit, and both recover.
+
+    Those two recoveries are separate call sites from the idempotent pre-check,
+    and each has to report on its own — the e2e covers only the sequential
+    repeat, where the pre-check is what answers. Driving `create_tranlog_async`
+    rather than the reporter, so the routing itself is what is under test.
+    """
+
+    def _armed(self, failure, winner, audit):
+        from unittest.mock import MagicMock
+
+        service = _make_service(audit)
+        service.tranlog_delivery_status_repo.create_status_async = AsyncMock()
+        service.tranlog_repository.start_transaction = AsyncMock(return_value=MagicMock())
+        service.tranlog_repository.create_tranlog_async = AsyncMock(side_effect=failure)
+        service.tranlog_repository.commit_transaction = AsyncMock()
+        service.tranlog_repository.abort_transaction = AsyncMock()
+        service.tranlog_repository.set_session = MagicMock()
+        service.tranlog_delivery_status_repo.set_session = MagicMock()
+        service.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+        service._get_setting_value_async = AsyncMock(return_value=None)
+        service._publish_tranlog_async = AsyncMock()
+        service.receipt_data_strategy = MagicMock()
+        service.receipt_data_strategy.make_receipt_data.return_value = MagicMock(receipt_text="R", journal_text="J")
+        return service
+
+    def _winner(self):
+        from kugel_common.models.documents.base_tranlog import BaseTransaction
+
+        winner = BaseTransaction()
+        winner.cart_id = "cart-190"
+        winner.tenant_id = "test_tenant"
+        winner.store_code = "S0001"
+        winner.transaction_no = 7
+        winner.receipt_no = 111117
+        winner.receipt_counter = 7
+        winner.generate_date_time = "2026-08-22T10:00:00"
+        winner.receipt_text = "R"
+        winner.journal_text = "J"
+        return winner
+
+    def _cart_carrying(self, counter):
+        from kugel_common.enums import TransactionType
+
+        from app.models.documents.cart_document import CartDocument
+
+        cart = CartDocument()
+        cart.cart_id = "cart-190"
+        cart.transaction_type = TransactionType.NormalSales.value
+        cart.business_date = "20260822"
+        cart.seq = 8
+        cart.receipt_counter = counter
+        cart.receipt_no = 111118
+        cart.transaction_datetime = "2026-08-22T10:00:07"
+        cart.sales = CartDocument.SalesInfo()
+        cart.sales.total_amount_with_tax = 110.0
+        cart.user = None
+        return cart
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            pytest.param("insert", id="the unique index rejects the insert"),
+            pytest.param("commit", id="the unique index rejects at commit"),
+        ],
+    )
+    async def test_a_divergent_loser_is_recorded(self, failure):
+        from kugel_common.exceptions import CannotCreateException, DuplicateKeyException
+
+        raised = (
+            DuplicateKeyException("dup", "log_tran", {}, None)
+            if failure == "insert"
+            else CannotCreateException("wrapped duplicate", "log_tran", {}, None)
+        )
+        audit = _audit()
+        service = self._armed(raised, self._winner(), audit)
+
+        await service.create_tranlog_async(self._cart_carrying(counter=9))
+
+        audit.add_record_async.assert_awaited_once()
+        assert audit.add_record_async.await_args.kwargs["result"] == "finalize_repeat_diverged"
+
+    async def test_a_loser_carrying_the_same_numbers_is_not(self):
+        from kugel_common.exceptions import DuplicateKeyException
+
+        audit = _audit()
+        winner = self._winner()
+        service = self._armed(DuplicateKeyException("dup", "log_tran", {}, None), winner, audit)
+        cart = self._cart_carrying(counter=winner.receipt_counter)
+        cart.seq = winner.transaction_no
+        cart.receipt_no = winner.receipt_no
+        cart.transaction_datetime = winner.generate_date_time
+
+        await service.create_tranlog_async(cart)
+
+        audit.add_record_async.assert_not_awaited()
+
+    async def test_a_repeat_reported_before_a_failed_commit_is_not_reported_again(self, caplog):
+        """The insert path can report and then fail to commit.
+
+        That lands in the recovery, which reports again — and by then the tranlog
+        in hand IS the recorded one, so the second report finds no divergence and
+        says the repeat "carried the same numbers". Directly after a line saying
+        it carried different ones. The audit row is not at risk (the second
+        comparison is the record against itself); the contradiction in the log
+        is, and that is what a reader has to work from.
+        """
+        audit = _audit()
+        winner = self._winner()
+        service = self._armed(None, winner, audit)
+        # A repeat detected by the pre-check: the repository hands back the row
+        # that was already there rather than raising.
+        service.tranlog_repository.create_tranlog_async = AsyncMock(return_value=winner)
+        service.tranlog_repository.commit_transaction = AsyncMock(side_effect=RuntimeError("commit lost"))
+        service.tranlog_repository.get_existing_finalize_async = AsyncMock(return_value=winner)
+
+        with caplog.at_level("WARNING"):
+            await service.create_tranlog_async(self._cart_carrying(counter=9))
+
+        reports = [r for r in caplog.records if "Finalize repeated" in r.getMessage()]
+        assert len(reports) == 1, (
+            f"the same repeat was reported {len(reports)} times: {[r.getMessage()[:60] for r in reports]}"
+        )
+        audit.add_record_async.assert_awaited_once()

--- a/services/cart/tests/unit/test_finalize_repeat_divergence.py
+++ b/services/cart/tests/unit/test_finalize_repeat_divergence.py
@@ -1,0 +1,175 @@
+# Copyright 2026 masa@kugel
+"""Telling a repeated finalize that repeats itself from one that does not (issue #190).
+
+`cart_id` is the transaction identity, so a second finalize for the same cart is
+answered with the transaction already recorded rather than writing another. That
+is right, and #152 pins it. What the log did not say is whether the repeat
+carried the SAME numbers.
+
+It usually does — a terminal that heard nothing has not advanced. When it does
+not, the terminal's running receipt counter has moved past what was recorded,
+and that means one of three things: it printed a receipt whose number is in no
+transaction log, it advanced without printing (a gap, which #166 allows), or a
+different transaction reused the cart_id. The first is worth chasing and the
+second is not, and until now both left the same single line behind.
+
+Detection only. What the caller gets back does not change.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.tran_service import TranService
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_service(audit=None):
+    terminal_info = MagicMock()
+    terminal_info.tenant_id = "test_tenant"
+    terminal_info.store_code = "S0001"
+    terminal_info.terminal_no = 1
+
+    with (
+        patch("app.services.tran_service.CartStrategyManager") as strategy_mgr,
+        patch("app.services.tran_service.PubsubManager"),
+    ):
+        strategy = MagicMock()
+        receipt_strategy = MagicMock()
+        receipt_strategy.name = "default"
+        strategy.load_strategies.return_value = [receipt_strategy]
+        strategy_mgr.return_value = strategy
+
+        return TranService(
+            terminal_info=terminal_info,
+            terminal_counter_repo=MagicMock(),
+            tranlog_repo=MagicMock(),
+            tranlog_delivery_status_repo=MagicMock(),
+            settings_master_repo=MagicMock(),
+            payment_master_repo=MagicMock(),
+            transaction_status_repo=MagicMock(),
+            cart_restore_log_repo=audit,
+        )
+
+
+def _tranlog(transaction_no=100, receipt_counter=41, receipt_no=111141, when="2026-08-22T10:30:00"):
+    return SimpleNamespace(
+        cart_id="cart-190",
+        tenant_id="test_tenant",
+        store_code="S0001",
+        transaction_no=transaction_no,
+        receipt_counter=receipt_counter,
+        receipt_no=receipt_no,
+        generate_date_time=when,
+    )
+
+
+def _audit():
+    audit = MagicMock()
+    audit.add_record_async = AsyncMock()
+    return audit
+
+
+async def _report(service, carried, recorded):
+    await service._TranService__report_finalize_repeat_async(carried, recorded)
+
+
+class TestARepeatThatRepeatsItself:
+    async def test_nothing_is_recorded_for_it(self, caplog):
+        # The ordinary case: the terminal heard nothing and sent the same thing
+        # again. Worth a line, not worth an audit row.
+        audit = _audit()
+        service = _make_service(audit)
+        recorded = _tranlog()
+
+        with caplog.at_level("WARNING"):
+            await _report(service, _tranlog(), recorded)
+
+        audit.add_record_async.assert_not_awaited()
+        assert any("cart-190" in r.getMessage() for r in caplog.records)
+
+    async def test_it_is_not_reported_as_an_error(self, caplog):
+        service = _make_service(_audit())
+
+        with caplog.at_level("WARNING"):
+            await _report(service, _tranlog(), _tranlog())
+
+        assert not [r for r in caplog.records if r.levelname == "ERROR"]
+
+
+class TestARepeatCarryingOtherNumbers:
+    @pytest.mark.parametrize(
+        "carried,field",
+        [
+            pytest.param(_tranlog(transaction_no=101), "transaction_no", id="the terminal counted another transaction"),
+            pytest.param(_tranlog(receipt_counter=42), "receipt_counter", id="the running receipt counter moved"),
+            pytest.param(_tranlog(receipt_no=111142), "receipt_no", id="a different number was printed"),
+            pytest.param(
+                _tranlog(when="2026-08-23T00:00:01"), "generate_date_time", id="across midnight, a different day"
+            ),
+        ],
+    )
+    async def test_the_difference_is_recorded(self, carried, field):
+        audit = _audit()
+        service = _make_service(audit)
+
+        await _report(service, carried, _tranlog())
+
+        audit.add_record_async.assert_awaited_once()
+        kwargs = audit.add_record_async.await_args.kwargs
+        assert kwargs["result"] == "finalize_repeat_diverged"
+        assert kwargs["cart_id"] == "cart-190"
+        assert kwargs["diverged"] is True
+        assert field in kwargs["reject_reason"], f"the reason does not name {field}: {kwargs['reject_reason']}"
+
+    async def test_the_reason_carries_both_values(self):
+        # A reader needs what was claimed and what is recorded; either alone says
+        # nothing about how far the terminal has moved.
+        audit = _audit()
+        service = _make_service(audit)
+
+        await _report(service, _tranlog(receipt_counter=42), _tranlog(receipt_counter=41))
+
+        reason = audit.add_record_async.await_args.kwargs["reject_reason"]
+        assert "42" in reason and "41" in reason, reason
+
+    async def test_it_is_reported_at_error(self, caplog):
+        service = _make_service(_audit())
+
+        with caplog.at_level("ERROR"):
+            await _report(service, _tranlog(receipt_counter=42), _tranlog())
+
+        assert [r for r in caplog.records if r.levelname == "ERROR"], "a divergence was not raised above a warning"
+
+    async def test_every_differing_field_is_named_at_once(self):
+        audit = _audit()
+        service = _make_service(audit)
+
+        await _report(service, _tranlog(transaction_no=101, receipt_counter=42), _tranlog())
+
+        reason = audit.add_record_async.await_args.kwargs["reject_reason"]
+        assert "transaction_no" in reason and "receipt_counter" in reason, reason
+
+
+class TestTheNoteMustNotCostTheTransaction:
+    async def test_an_audit_write_that_fails_is_swallowed(self, caplog):
+        # The transaction is recorded and the caller has been answered. Losing
+        # the note about it must not turn that into a failure.
+        audit = _audit()
+        audit.add_record_async.side_effect = RuntimeError("the audit collection is unavailable")
+        service = _make_service(audit)
+
+        with caplog.at_level("ERROR"):
+            await _report(service, _tranlog(receipt_counter=42), _tranlog())
+
+        assert any("Could not record" in r.message for r in caplog.records)
+
+    async def test_no_audit_repository_still_logs(self, caplog):
+        service = _make_service(audit=None)
+
+        with caplog.at_level("ERROR"):
+            await _report(service, _tranlog(receipt_counter=42), _tranlog())
+
+        assert [r for r in caplog.records if r.levelname == "ERROR"]

--- a/services/cart/tests/unit/test_finalize_repeat_divergence.py
+++ b/services/cart/tests/unit/test_finalize_repeat_divergence.py
@@ -173,3 +173,63 @@ class TestTheNoteMustNotCostTheTransaction:
             await _report(service, _tranlog(receipt_counter=42), _tranlog())
 
         assert [r for r in caplog.records if r.levelname == "ERROR"]
+
+
+class TestWhoDidTheNumbering:
+    """Only a terminal's numbers can diverge from what was recorded.
+
+    On the server-numbered path the numbers in hand were issued by *this* request
+    from the server's own counter and clock, so a race against a concurrent
+    finalize differs by construction. Measured on the running stack with two
+    simultaneous bills and no snapshot: `carried 50 vs recorded 49`, timestamps
+    apart by microseconds — and nothing there is a terminal that moved on.
+    Filing those would bury the rows that mean something.
+    """
+
+    async def test_a_server_numbered_repeat_is_not_a_divergence(self):
+        audit = _audit()
+        service = _make_service(audit)
+
+        await service._TranService__report_finalize_repeat_async(
+            _tranlog(transaction_no=50, receipt_no=111160), _tranlog(transaction_no=49), client_numbered=False
+        )
+
+        audit.add_record_async.assert_not_awaited()
+
+    async def test_a_client_numbered_repeat_still_is(self):
+        audit = _audit()
+        service = _make_service(audit)
+
+        await service._TranService__report_finalize_repeat_async(
+            _tranlog(transaction_no=50), _tranlog(transaction_no=49), client_numbered=True
+        )
+
+        audit.add_record_async.assert_awaited_once()
+
+
+class TestTheSameInstantWrittenTwoWays:
+    @pytest.mark.parametrize(
+        "carried_when,recorded_when",
+        [
+            pytest.param("2026-08-22T10:30:00+00:00", "2026-08-22T10:30:00Z", id="Z against an explicit offset"),
+            pytest.param("2026-08-22T10:30:00.000000+09:00", "2026-08-22T10:30:00+09:00", id="zero microseconds"),
+        ],
+    )
+    async def test_it_is_not_reported_as_a_divergence(self, carried_when, recorded_when):
+        # The carried value is validated as ISO-8601 and not normalised, so the
+        # same moment can arrive written differently. Comparing the strings would
+        # report a terminal that had not moved at all.
+        audit = _audit()
+        service = _make_service(audit)
+
+        await _report(service, _tranlog(when=carried_when), _tranlog(when=recorded_when))
+
+        audit.add_record_async.assert_not_awaited()
+
+    async def test_a_genuinely_different_time_still_is(self):
+        audit = _audit()
+        service = _make_service(audit)
+
+        await _report(service, _tranlog(when="2026-08-23T00:00:01+09:00"), _tranlog(when="2026-08-22T23:59:59+09:00"))
+
+        audit.add_record_async.assert_awaited_once()


### PR DESCRIPTION
Closes #190.

## What it changes

A second finalize for the same `cart_id` is answered with the transaction already recorded rather than writing another — right, and pinned by #152. What the log did not say is whether the repeat carried the **same numbers**.

| | first attempt | repeat | recorded |
|---|---|---|---|
| **an honest retry** | seq=100, counter=41 | seq=100, counter=41 | 100 / 41 |
| **the terminal advanced** | seq=100, counter=41 | seq=101, counter=42 | 100 / 41 |

Both produced one tranlog and one identical log line. The values the repeat carried were written nowhere.

Now the two are told apart. An identical repeat stays a warning; a divergent one is an ERROR naming every field that differs with both values, plus an audit row through the same trail #168 writes its numbering divergence to — so the set worth reconciling against printed receipts is a query rather than a reading of logs.

Live:

```
identical repeat             HTTP 200  audit rows: 0
repeat with other numbers    HTTP 200  audit rows: 1
    reason: transaction_no: carried 8527 vs recorded 8526,
            receipt_no: carried 111112 vs recorded 111111,
            receipt_counter: carried 2 vs recorded 1
    diverged flag: True
```

## Which numbers

The four the terminal carries in its finalize context (#156): `transaction_no` (from `seq`), `receipt_no`, `receipt_counter`, `generate_date_time`.

`receipt_counter` is the one that matters most — it is what a printed receipt number is derived from, so a terminal ahead of the record may have handed a customer a number that appears in no transaction log. `generate_date_time` usually differs by seconds and matters when it crosses midnight, because that is the business date the transaction is counted in.

## Detection only

As the issue asks. What the caller gets back does not change: the sale stays recorded once, and the response still carries the numbers that were actually recorded. An audit write that fails is swallowed — the transaction is recorded and answered, and losing the note about it must not turn that into a failure.

Both repeat paths report: the idempotent pre-check and the concurrent-race recovery, so an ordinary retry and the #172 race are told apart the same way.

## Verification

| mutation | tests that fail |
|---|---|
| never see a divergence | 1 |
| audit every repeat, divergent or not | 1 |
| compare only the transaction number | 1 |
| let an audit failure escape | 1 |

cart unit 648 · cart integration 76 · all e2e — green.

## Related

This is the last open item under the #146 umbrella that is code rather than a prerequisite: its design table settles replay as *"accept + detect: idempotent finalization keyed on cart_id + audit trail"*, and this is the half of the audit trail that was missing. What remains there is demoting the server-side cache (blocked on clients migrating to `CART_REQUEST_SNAPSHOT_MODE=REQUIRED`) and measuring real cart sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Am91TDvKrDiLa6DfeU8cB
