### PR TITLE
fix(master-data): create an item book with its categories (#197)

### DIFF
--- a/services/master-data/app/api/v1/item_book_master.py
+++ b/services/master-data/app/api/v1/item_book_master.py
@@ -78,7 +78,16 @@ async def create_item_book(
     service = await get_item_book_service_async(tenant_id)
 
     try:
-        new_item_book = await service.create_item_book_async(title=item_book.title, categories=item_book.categories)
+        # Serialised here, not handed over as models: create_item_book_async
+        # takes list[dict] and builds ItemBookCategory(**category) from each
+        # entry, so passing the request's own models raised TypeError and the
+        # route answered an unhandled 500 for any book carrying a category
+        # (issue #197). The update route below has always serialised first,
+        # which is why only create was affected.
+        new_item_book = await service.create_item_book_async(
+            title=item_book.title,
+            categories=[category.model_dump() for category in item_book.categories],
+        )
         transformer = SchemasTransformerV1()
         return_item_book = transformer.transform_item_book(new_item_book)
         logger.debug(f"return_item_book: {return_item_book}")
@@ -318,7 +327,7 @@ async def update_item_book(
     service = await get_item_book_service_async(tenant_id)
 
     try:
-        updated_item_book = await service.update_item_book_async(item_book_id, item_book.dict())
+        updated_item_book = await service.update_item_book_async(item_book_id, item_book.model_dump())
         transformer = SchemasTransformerV1()
         return_item_book = transformer.transform_item_book(updated_item_book)
     except Exception as e:

--- a/services/master-data/tests/integration/test_item_books_crud.py
+++ b/services/master-data/tests/integration/test_item_books_crud.py
@@ -230,3 +230,101 @@ async def test_item_book_button_put_delete(http_client, admin_header, category_n
         headers=admin_header,
     )
     assert response.status_code == status.HTTP_200_OK
+
+
+# =========================================================================
+# Creating with a populated tree (issue #197)
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_item_book_with_a_populated_tree(http_client, admin_header):
+    """The create request carries categories -> tabs -> buttons in one body.
+
+    Every other test here creates with `"categories": []` and builds the tree
+    afterwards through the sub-resource endpoints, so nothing exercised the
+    shape the schema actually declares. The route handed the request's own
+    Pydantic models to a service that builds ItemBookCategory(**category) from
+    dicts, and answered an unhandled 500 for any book carrying a category.
+    """
+    tenant_id = os.environ.get("TENANT_ID")
+    await _ensure_tenant(http_client, admin_header, tenant_id)
+
+    payload = {
+        "title": "Spring Menu",
+        "categories": [
+            {
+                "categoryNumber": 1,
+                "title": "Drinks",
+                "color": "#9AA5B1",
+                "tabs": [
+                    {
+                        "tabNumber": 1,
+                        "title": "Hot",
+                        "color": "#E4E7EB",
+                        "buttons": [
+                            {
+                                "posX": 0,
+                                "posY": 0,
+                                "size": "Single",
+                                "imageUrl": "https://cdn.example.co.jp/coffee.webp",
+                                "colorText": "#1F2933",
+                                "itemCode": "49-01",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    response = await http_client.post(
+        f"/api/v1/tenants/{tenant_id}/item_books", json=payload, headers=admin_header
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    item_book_id = response.json()["data"]["itemBookId"]
+
+    # Read it back: the tree has to survive the round trip, not merely be accepted.
+    response = await http_client.get(
+        f"/api/v1/tenants/{tenant_id}/item_books/{item_book_id}", headers=admin_header
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    data = response.json()["data"]
+    assert data["title"] == "Spring Menu"
+    category = data["categories"][0]
+    assert category["categoryNumber"] == 1
+    assert category["title"] == "Drinks"
+    tab = category["tabs"][0]
+    assert tab["tabNumber"] == 1
+    button = tab["buttons"][0]
+    assert button["itemCode"] == "49-01"
+    assert button["posX"] == 0
+    assert button["size"] == "Single"
+
+
+@pytest.mark.asyncio
+async def test_create_item_book_with_several_categories(http_client, admin_header):
+    """More than one category, so the per-entry conversion is exercised as a list."""
+    tenant_id = os.environ.get("TENANT_ID")
+    await _ensure_tenant(http_client, admin_header, tenant_id)
+
+    categories = [
+        {
+            "categoryNumber": n,
+            "title": f"Category {n}",
+            "color": "#9AA5B1",
+            "tabs": [{"tabNumber": 1, "title": "T", "color": "#E4E7EB", "buttons": []}],
+        }
+        for n in (1, 2, 3)
+    ]
+
+    response = await http_client.post(
+        f"/api/v1/tenants/{tenant_id}/item_books",
+        json={"title": "Multi", "categories": categories},
+        headers=admin_header,
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    assert [c["categoryNumber"] for c in response.json()["data"]["categories"]] == [1, 2, 3]


### PR DESCRIPTION
Closes #197. Branched off `main` — independent of the #195 work (#198 / #201), though that is where it was found.

## The bug

`POST /tenants/{tenant_id}/item_books` declares the whole tree in its request schema (`schemas.py:522`):

```python
class BaseItemBookCreateRequest(BaseSchemaModel):
    title: str
    categories: Optional[list[BaseItemBookCategory]] = []
```

and answered an unhandled 500 for any book carrying even one category:

```json
{"success": false, "code": 500, "message": "Internal server error",
 "user_error": {"code": "900999", "message": "予期しないエラーが発生しました"},
 "data": "ItemBookCategory() argument after ** must be a mapping, not BaseItemBookCategory"}
```

The route passed `item_book.categories` — a list of Pydantic models — to a service typed `list[dict]` that builds `ItemBookCategory(**category)` from each entry (`item_book_master_service.py:52`, `:68`).

`{"title": "T", "categories": []}` succeeded, so only the populated path was affected.

## The fix

Serialise at the boundary, which is what the update route has always done:

```python
new_item_book = await service.create_item_book_async(
    title=item_book.title,
    categories=[category.model_dump() for category in item_book.categories],
)
```

That asymmetry is why only create broke: `PUT` passes `item_book.dict()`. So an item book *could* be populated in one call — but only by creating it empty and then updating it.

The update route moves from the deprecated `.dict()` to `model_dump()` at the same time, since it was the line being read for the correct behaviour.

## Why it stayed green

Every existing test in `test_item_books_crud.py` and `test_operations.py` creates with `"categories": []` and builds the tree afterwards through the sub-resource endpoints. Nothing exercised the shape the schema declares, so a route that always 500s on its documented input passed CI.

Two tests added, both of which fail without the fix:

- `test_create_item_book_with_a_populated_tree` — creates category → tab → button in one request, then **reads it back** and asserts the tree survived, rather than only that the request was accepted
- `test_create_item_book_with_several_categories` — more than one category, so the per-entry conversion is exercised as a list

Confirmed to discriminate by stashing the fix:

```
FAILED test_create_item_book_with_a_populated_tree
FAILED test_create_item_book_with_several_categories
2 failed, 4 passed
```

and with the fix applied, 6 passed.

## Tests run

- master-data **unit: 397 passed**
- master-data **integration: 22 passed**

e2e was not run: the containers currently on this machine are built from the #201 branch, so a run would exercise stale images, and rebuilding the stack to cover a route-level serialisation bug adds nothing over the integration tier — which runs the real route against real MongoDB. Say the word if you want it anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
